### PR TITLE
Fix to resolve Error: missing field `modules` at line 6 column 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,15 +107,15 @@ The WAGI server uses a `modules.toml` file to point to the WAGI modules that can
 Here is an example `modules.toml`:
 
 ```toml
-[[module]]
+[[modules]]
 route = "/"
 module = "/absolute/path/to/root.wasm"
 
-[[module]]
+[[modules]]
 route = "/foo"
 module = "/path/to/foo.wasm"
 
-[[module]]
+[[modules]]
 # The "/..." suffix means this will match /bar and its subpaths, like /bar/a/b/c
 route = "/bar/..."
 module = "/path/to/bar.wasm"
@@ -124,7 +124,7 @@ volumes = {"/path/inside/wasm": "/path/on/host"}
 # You can also put static environment variables in the TOML file
 environment.TEST_NAME = "test value" 
 
-[[module]]
+[[modules]]
 # You can also execute a WAT file directly
 route = "/hello"
 module = "/path/to/hello.wat"
@@ -133,7 +133,7 @@ module = "/path/to/hello.wat"
 
 - Top-level fields
   - Currently none
-- The `[[module]]` list: Each module starts with a `[[module]]` header. Inside of a module, the following fields are available:
+- The `[[modules]]` list: Each module starts with a `[[modules]]` header. Inside of a module, the following fields are available:
   - `route`: The path that is appended to the server URL to create a full URL (e.g. `/foo` becomes `https://example.com/foo`)
   - `module`: The absolute path to the module on the file system
   - `environment`: A list of string/string environment variable pairs.

--- a/examples/modules.toml
+++ b/examples/modules.toml
@@ -1,9 +1,9 @@
-[[module]]
+[[modules]]
 # Example executing a Web Assembly Text file
 route = "/"
 module = "examples/hello.wat"
 
-[[module]]
+[[modules]]
 # Example running a WASM file.
 route = "/hello/..."
 module = "examples/hello.wasm"


### PR DESCRIPTION
to address a de-serialization issue on parsing modules.toml that caused **Error: missing field `modules` at line 6 column 1** fixing the typos in read me and **modules.toml** file in example directory.  
_In lib.rs file line number 73 to 76 expects de-serialization key as [[modules]] but examples files and readme refers to use [[module]]_
`#[derive(Clone, Deserialize)]
pub struct ModuleConfig {
    pub modules: Vec<Module>,
}
`
Post fixing these typos in readme and example  directory i was successfully able to run WAGI server as expected