### PR TITLE
Fixed de-serialization issue on parsing modules.toml file

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,8 @@ impl Router {
 /// The configuration for all modules in a WAGI site
 #[derive(Clone, Deserialize)]
 pub struct ModuleConfig {
+    /// this line de-serializes [[module]] as modules
+    #[serde(rename = "module")]
     pub modules: Vec<Module>,
 }
 


### PR DESCRIPTION
added serde rename to de-serialize [[module]] as modules to resolve Error: missing field `modules` at line 6 column 1 #16 