### PR TITLE
added logger and replaced a bunch of printlns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -445,7 +445,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 dependencies = [
  "atty",
- "humantime",
+ "humantime 1.3.0",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17392a012ea30ef05a610aa97dfb49496e71c9f676b27879922ea5bdf60d9d3f"
+dependencies = [
+ "atty",
+ "humantime 2.1.0",
  "log",
  "regex",
  "termcolor",
@@ -484,7 +497,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fdbe0d94371f9ce939b555dd342d0686cc4c0cadbcd4b61d70af5ff97eb4126"
 dependencies = [
- "env_logger",
+ "env_logger 0.7.1",
  "log",
 ]
 
@@ -741,6 +754,12 @@ checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 dependencies = [
  "quick-error",
 ]
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -1651,8 +1670,10 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "env_logger 0.8.3",
  "futures",
  "hyper",
+ "log",
  "serde",
  "tempfile",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,8 @@ authors = ["Matt Butcher <matt.butcher@microsoft.com>"]
 edition = "2018"
 
 [dependencies]
+log = "0.4"
+env_logger = "0.8"
 hyper = {version = "0.14", features = ["full"]}
 tokio = { version = "1.1", features = ["full"] }
 futures = "0.3"

--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,8 @@ build:
 .PHONY: run
 run:
 	RUST_LOG=$(LOG_LEVEL) cargo run --release -- -c $(MODULES_TOML)
+
+.PHONY: test
+test:
+	cargo test
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+LOG_LEVEL ?= info
+MODULES_TOML ?= examples/modules.toml
+
+.PHONY: build
+build:
+	cargo build --release
+
+.PHONY: run
+run:
+	RUST_LOG=$(LOG_LEVEL) cargo run --release -- -c $(MODULES_TOML)

--- a/src/http_util.rs
+++ b/src/http_util.rs
@@ -12,7 +12,7 @@ pub(crate) fn not_found() -> Response<Body> {
 
 /// Create an HTTP 500 response
 pub(crate) fn internal_error(msg: &str) -> Response<Body> {
-    println!("HTTP 500 error: {}", msg);
+    log::error!("HTTP 500 error: {}", msg);
     let mut res = Response::new(Body::from(msg.to_owned()));
     *res.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
     res
@@ -23,7 +23,7 @@ pub(crate) fn parse_cgi_headers(headers: String) -> HashMap<String, String> {
     headers.trim().split('\n').for_each(|h| {
         let parts: Vec<&str> = h.splitn(2, ':').collect();
         if parts.len() != 2 {
-            println!("corrupt header: {}", h);
+            log::warn!("corrupt header: {}", h);
             return;
         }
         map.insert(parts[0].trim().to_owned(), parts[1].trim().to_owned());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@ impl Router {
                     )
                     .await),
                 Err(e) => {
-                    eprintln!("error: {}", e);
+                    log::error!("error: {}", e);
                     Ok(not_found())
                 }
             },
@@ -163,7 +163,7 @@ impl ModuleConfig {
                 if r.path
                     .strip_suffix("/...")
                     .map(|i| {
-                        println!("Comparing {} to {}", uri_fragment.clone(), r.path.as_str());
+                        log::info!("Comparing {} to {}", uri_fragment.clone(), r.path.as_str());
                         uri_fragment.starts_with(i)
                     })
                     .unwrap_or_else(|| r.path == uri_fragment)

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use hyper::{
     service::{make_service_fn, service_fn},
 };
 use hyper::{Body, Request, Response, Server};
+use log::*;
 use std::{
     net::SocketAddr,
     sync::{Arc, Mutex},
@@ -12,6 +13,7 @@ use wagi::Router;
 
 #[tokio::main]
 pub async fn main() -> Result<(), anyhow::Error> {
+    env_logger::init();
     let matches = App::new("WAGI Server")
         .version("0.1.0")
         .author("DeisLabs")
@@ -41,12 +43,13 @@ pub async fn main() -> Result<(), anyhow::Error> {
         )
         .get_matches();
 
-    println!("=> Starting server");
-    let addr = matches
+    let addr: SocketAddr = matches
         .value_of("listen")
         .unwrap_or("127.0.0.1:3000")
         .parse()
         .unwrap();
+
+    info!("=> Starting server on {}", addr.to_string());
 
     // We have to pass a cache file configuration path to a Wasmtime engine.
     let cache_config_path = String::from(matches.value_of("cache").unwrap_or("cache.toml"));
@@ -79,7 +82,7 @@ pub async fn main() -> Result<(), anyhow::Error> {
     let srv = Server::bind(&addr).serve(mk_svc);
 
     if let Err(e) = srv.await {
-        eprintln!("server error: {}", e);
+        error!("server error: {}", e);
     }
     Ok(())
 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -101,7 +101,7 @@ impl Module {
         match self.run_wasm(entrypoint, &parts, data, client_addr, cache_config_path) {
             Ok(res) => res,
             Err(e) => {
-                eprintln!("error running WASM module: {}", e);
+                log::error!("error running WASM module: {}", e);
                 // A 500 error makes sense here
                 let mut srv_err = Response::default();
                 *srv_err.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
@@ -153,7 +153,7 @@ impl Module {
         let instance = linker.instantiate(&module)?;
 
         let duration = start_time.elapsed();
-        println!(
+        log::info!(
             "(load_routes) instantiation time for module {}: {:#?}",
             self.module.as_str(),
             duration
@@ -389,7 +389,7 @@ impl Module {
                     Ok(dir) => {
                         builder.preopened_dir(dir, guest);
                     }
-                    Err(e) => eprintln!("Error opening {} -> {}: {}", host, guest, e),
+                    Err(e) => log::error!("Error opening {} -> {}: {}", host, guest, e),
                 }
             }
         }
@@ -402,7 +402,7 @@ impl Module {
         let instance = linker.instantiate(&module)?;
 
         let duration = start_time.elapsed();
-        println!(
+        log::info!(
             "instantiation time for module {}: {:#?}",
             self.module.as_str(),
             duration
@@ -460,7 +460,7 @@ impl Module {
                     }
                     "status" => {
                         if let Ok(status) = h.1.parse::<hyper::StatusCode>() {
-                            println!("Setting status to {}", status);
+                            log::info!("Setting status to {}", status);
                             *res.status_mut() = status;
                         }
                     }
@@ -478,7 +478,7 @@ impl Module {
                                 res.headers_mut()
                                     .insert(hdr, HeaderValue::from_str(h.1).unwrap());
                             }
-                            Err(e) => eprintln!("Invalid header name '{}': {}", h.0.as_str(), e),
+                            Err(e) => log::error!("Invalid header name '{}': {}", h.0.as_str(), e),
                         }
                     }
                 }
@@ -562,7 +562,7 @@ mod test {
 
         mc.build_registry(cache).expect("registry build cleanly");
 
-        println!("{:#?}", mc.route_cache);
+        log::debug!("{:#?}", mc.route_cache);
 
         // Three routes for each module.
         assert_eq!(6, mc.route_cache.as_ref().expect("routes are set").len());


### PR DESCRIPTION
This adds `log` and `env_logger` and then switches all the `println` and `eprintln` macros over to logger macros.

This also adds a `Makefile` that simplifies some of the commands we usually run.

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>