### PR TITLE
fixed a bug with the HOST header and the default host

### DIFF
--- a/docs/configuring_and_running.md
+++ b/docs/configuring_and_running.md
@@ -171,13 +171,13 @@ If a client requests `https://example.com/`, WAGI will execute the `hello.wasm` 
 If the client requests `https://another.example.com`, WAGI will execute the `goodbye.wasm` module.
 If no matching host is found, WAGI will serve an error.
 
-To provide a default host, set the `defaultHost` field at the top of your `modules.toml`.
+To provide a default host, set the `default_host` field at the top of your `modules.toml`.
 Any module that does not declare a `host` will automatically listen (only) on the
-`defaultHost`. If no `defaultHost` is specified and a module does not provide a `host`, then
-WAGI will use `localhost` as the default host.
+`default_host`. If no `default_host` is specified and a module does not provide a `host`, then
+WAGI will use `localhost:3000` as the default host.
 
 ```toml
-defaultHost = "my.example.com"
+default_host = "my.example.com"
 
 # With no `entrypoint`, this will invoke `_start()`
 [[module]]

--- a/examples/modules.toml
+++ b/examples/modules.toml
@@ -1,3 +1,5 @@
+default_host = "localhost:3000"
+
 [[module]]
 # Example executing a Web Assembly Text file
 route = "/"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,9 @@ mod http_util;
 pub mod runtime;
 pub mod version;
 
+/// The default host is 'localhost:3000' because that is the port and host WAGI has used since introduction.
+pub const DEFAULT_HOST: &str = "localhost:3000";
+
 #[derive(Clone)]
 /// A router is responsible for taking an inbound request and sending it to the appropriate handler.
 pub struct Router {
@@ -150,7 +153,6 @@ pub struct ModuleConfig {
     /// That is, the `HOST` field of an HTTP 1.1 request must match either the default
     /// host name specified in this paramter or match the `host` field on the module
     /// that matches this request's path.
-    #[serde(rename = "defaultHost")]
     default_host: Option<String>,
 
     /// this line de-serializes [[module]] as modules
@@ -201,7 +203,7 @@ impl ModuleConfig {
         let default_host = self
             .default_host
             .clone()
-            .unwrap_or_else(|| "localhost".to_owned());
+            .unwrap_or_else(|| DEFAULT_HOST.to_owned());
         if let Some(routes) = self.route_cache.as_ref() {
             for r in routes {
                 // The request must match either the `host` of an entry or the `default_host`
@@ -229,7 +231,7 @@ impl ModuleConfig {
             }
         }
 
-        Err(anyhow::anyhow!("No handler for {}", uri_fragment))
+        Err(anyhow::anyhow!("No handler for //{}{}", host, uri_fragment))
     }
 }
 
@@ -271,7 +273,7 @@ mod test {
 
         // This should match a default handler
         let foo = mc
-            .handler_for_host_path("localhost", "/")
+            .handler_for_host_path(super::DEFAULT_HOST, "/")
             .expect("foo.example.com handler found");
         assert!(foo.host.is_none());
 

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -499,6 +499,7 @@ impl Module {
 #[cfg(test)]
 mod test {
     use crate::ModuleConfig;
+    use crate::DEFAULT_HOST as LOCALHOST;
 
     use super::Module;
     use std::io::Write;
@@ -571,14 +572,14 @@ mod test {
 
         // Base route is from the config file
         let base = mc
-            .handler_for_host_path("localhost", "/base")
+            .handler_for_host_path(LOCALHOST, "/base")
             .expect("Should get a /base route");
         assert_eq!("_start", base.entrypoint);
         assert_eq!(modpath, base.module.module);
 
         // Route one is from the module's _routes()
         let one = mc
-            .handler_for_host_path("localhost", "/base/one")
+            .handler_for_host_path(LOCALHOST, "/base/one")
             .expect("Should get the /base/one route");
 
         assert_eq!("one", one.entrypoint);
@@ -586,7 +587,7 @@ mod test {
 
         // Route two is a wildcard.
         let two = mc
-            .handler_for_host_path("localhost", "/base/two/three")
+            .handler_for_host_path(LOCALHOST, "/base/two/three")
             .expect("Should get the /base/two/... route");
 
         assert_eq!("two", two.entrypoint);
@@ -594,11 +595,11 @@ mod test {
 
         // This should fail
         assert!(mc
-            .handler_for_host_path("localhost", "/base/no/such/path")
+            .handler_for_host_path(LOCALHOST, "/base/no/such/path")
             .is_err());
 
         // This should pass
-        mc.handler_for_host_path("localhost", "/another/path")
+        mc.handler_for_host_path(LOCALHOST, "/another/path")
             .expect("The generic handler should have been returned for this");
     }
 


### PR DESCRIPTION
I introduced a bug recently with my host naming addition.

The correct default host is `locahost:3000` (with the port), but I had set it in several places to be just `localhost`.

Additionally, I did some research and it looks like the idiomatic format for multi-word TOML names is to use an underscore, not camel case. So I switched `defaultHost` to `default_host`.

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>