### PR TITLE
Refactoring the router

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ wasmtime-wasi = "0.22"
 wasmtime-cache = "0.22"
 wasi-common = "0.22"
 clap = "2.33.3"
-tempfile = "3.2"
-bindle = "0.3"
+bindle = { version = "0.3", default-features = false, features = ["client", "server", "caching"] }
 url = "2.2"
+
+[dev-dependencies]
+tempfile = "3.2"

--- a/src/http_util.rs
+++ b/src/http_util.rs
@@ -11,9 +11,10 @@ pub(crate) fn not_found() -> Response<Body> {
 }
 
 /// Create an HTTP 500 response
-pub(crate) fn internal_error(msg: &str) -> Response<Body> {
-    log::error!("HTTP 500 error: {}", msg);
-    let mut res = Response::new(Body::from(msg.to_owned()));
+pub(crate) fn internal_error(msg: impl std::string::ToString) -> Response<Body> {
+    let message = msg.to_string();
+    log::error!("HTTP 500 error: {}", message);
+    let mut res = Response::new(Body::from(message));
     *res.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
     res
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,30 +82,6 @@ impl Router {
             },
         }
     }
-
-    /*
-    /// Reload the config and modules.
-    ///
-    /// This rebuilds the modules list from config, and then re-initializes all
-    /// modules. It will call the `_routes()` method on each module. If caching is
-    /// enabled, it will also clear and recreate the module cache.
-
-    fn reload(&self) -> anyhow::Result<()> {
-        let new_config = load_modules_toml(
-            self.module_config_path.as_str(),
-            self.cache_config_path.clone(),
-        )
-        .await?;
-        {
-            let mut module_config = self.module_config.write().await;
-            *module_config = new_config;
-            module_config
-                .build_registry(self.cache_config_path.clone())
-                .await?;
-        }
-        Ok(())
-    }
-    */
 }
 
 /// Load the configuration TOML
@@ -149,6 +125,7 @@ impl ModuleStore {
     async fn run(&self) {
         loop {
             self.notify.notified().await;
+            log::debug!("Reloading module configuration");
             let new_config = match load_modules_toml(
                 self.module_config_path.as_str(),
                 self.cache_config_path.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,12 @@ pub async fn main() -> Result<(), anyhow::Error> {
     let mk_svc = make_service_fn(move |conn: &AddrStream| {
         let addr = conn.remote_addr();
         let r = router.clone();
-        async move { Ok::<_, std::convert::Infallible>(service_fn(move |req| r.route(req, addr))) }
+        async move {
+            Ok::<_, std::convert::Infallible>(service_fn(move |req| {
+                let r2 = r.clone();
+                async move { r2.route(req, addr).await }
+            }))
+        }
     });
 
     let srv = Server::bind(&addr).serve(mk_svc);

--- a/src/runtime/bindle.rs
+++ b/src/runtime/bindle.rs
@@ -16,6 +16,8 @@ pub(crate) async fn load_bindle(server: &str, uri: &Url) -> anyhow::Result<wasmt
     // TODO: We need to load a keyring and then get it all the way here.
     //invoice.verify(keyring)
 
+    // TODO: We should probably turn on the LRU.
+
     // For now, we grab a list of parcels that have no conditions.
     // This is definitely not the best strategy.
     let parcels = invoice.parcel;

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -46,18 +46,20 @@ pub struct Handler {
     // This path is the _fully constructed_ path. That is, if a module config declares its path as `/base`,
     // and the module registers the path `/foo/...`, the value of this would be `/base/foo/...`.
     pub path: String,
-    pub host: Option<String>,
 }
 
 impl Handler {
     /// Given a module and a route entry, create a new handler.
-    pub fn new(entry: &RouteEntry, module: &Module) -> Self {
+    pub fn new(entry: RouteEntry, module: Module) -> Self {
         Handler {
-            path: entry.path.clone(),
-            entrypoint: entry.entrypoint.clone(),
-            module: module.clone(),
-            host: module.host.clone(),
+            path: entry.path,
+            entrypoint: entry.entrypoint,
+            module: module,
         }
+    }
+
+    pub fn host(&self) -> Option<&String> {
+        self.module.host.as_ref()
     }
 }
 
@@ -107,8 +109,18 @@ impl Module {
             .await
             .unwrap_or_default()
             .to_vec();
-
-        match self.run_wasm(entrypoint, &parts, data, client_addr, cache_config_path) {
+        let ep = entrypoint.to_owned();
+        let me = self.clone();
+        let res = match tokio::task::spawn_blocking(move || {
+            me.run_wasm(&ep, &parts, data, client_addr, cache_config_path)
+        })
+        .await
+        {
+            Ok(res) => res,
+            Err(e) if e.is_panic() => return internal_error("Module run error"),
+            Err(e) => return internal_error("module run was cancelled"),
+        };
+        match res {
             Ok(res) => res,
             Err(e) => {
                 log::error!("error running WASM module: {}", e);
@@ -123,7 +135,7 @@ impl Module {
     /// Examine the given module to see if it has any routes.
     ///
     /// If it has any routes, add them to the vector and return it.
-    pub async fn load_routes(
+    pub(crate) fn load_routes(
         &self,
         cache_config_path: String,
     ) -> Result<Vec<RouteEntry>, anyhow::Error> {
@@ -162,7 +174,11 @@ impl Module {
         let wasi = Wasi::new(&store, ctx);
         wasi.add_to_linker(&mut linker)?;
 
-        let module = self.load_module(&store).await?;
+        // TODO: This could be reallllllllly dangerous as we are for sure going to block at this
+        // point on this current thread. This _should_ be ok given that we run this as a
+        // spawn_blocking, but those sound like famous last words waiting to happen. Refactor this
+        // sooner rather than later
+        let module = futures::executor::block_on(self.load_module(&store))?;
         let instance = linker.instantiate(&module)?;
 
         let duration = start_time.elapsed();

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -117,8 +117,14 @@ impl Module {
         .await
         {
             Ok(res) => res,
-            Err(e) if e.is_panic() => return internal_error("Module run error"),
-            Err(e) => return internal_error("module run was cancelled"),
+            Err(e) if e.is_panic() => {
+                log::error!("Recoverable panic on Wasm Runner thread: {}", e);
+                return internal_error("Module run error");
+            }
+            Err(e) => {
+                log::error!("Recoverable panic on Wasm Runner thread: {}", e);
+                return internal_error("module run was cancelled");
+            }
         };
         match res {
             Ok(res) => res,


### PR DESCRIPTION
This PR rewrites the core router so that it is able to reload modules after fetching them from Bindle. In the course of doing this, @thomastaylor312 and I (mostly Taylor) rewrite the core router and module loading, decoupling the configuration aspect from the routing logic.