### PR TITLE
Support pulling OCI images

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,15 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "base64"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
@@ -157,7 +166,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "toml",
- "url",
+ "url 2.2.1",
  "warp",
 ]
 
@@ -235,6 +244,16 @@ name = "byteorder"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+
+[[package]]
+name = "bytes"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
+dependencies = [
+ "byteorder",
+ "iovec",
+]
 
 [[package]]
 name = "bytes"
@@ -757,7 +776,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
- "percent-encoding",
+ "percent-encoding 2.1.0",
 ]
 
 [[package]]
@@ -888,7 +907,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 dependencies = [
  "typenum",
- "version_check",
+ "version_check 0.9.2",
 ]
 
 [[package]]
@@ -941,7 +960,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.1",
  "indexmap",
  "slab",
  "tokio",
@@ -969,7 +988,7 @@ dependencies = [
  "bitflags",
  "bytes 1.0.1",
  "headers-core",
- "http",
+ "http 0.2.1",
  "mime",
  "sha-1 0.8.2",
  "time",
@@ -981,7 +1000,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 dependencies = [
- "http",
+ "http 0.2.1",
 ]
 
 [[package]]
@@ -1004,6 +1023,17 @@ dependencies = [
 
 [[package]]
 name = "http"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6ccf5ede3a895d8856620237b2f02972c1bbc78d2965ad7fe8838d4a0ed41f0"
+dependencies = [
+ "bytes 0.4.12",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
@@ -1020,7 +1050,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2861bd27ee074e5ee891e8b539837a9430012e249d7f0ca2d795650f579c1994"
 dependencies = [
  "bytes 1.0.1",
- "http",
+ "http 0.2.1",
 ]
 
 [[package]]
@@ -1061,7 +1091,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 0.2.1",
  "http-body",
  "httparse",
  "httpdate",
@@ -1085,6 +1115,35 @@ dependencies = [
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "hyperx"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4a94cbc2c6f63028e5736ca4e811ae36d3990059c384cbe68298c66728a9776"
+dependencies = [
+ "base64 0.10.1",
+ "bytes 0.4.12",
+ "http 0.1.21",
+ "httparse",
+ "language-tags",
+ "log",
+ "mime",
+ "percent-encoding 1.0.1",
+ "time",
+ "unicase 2.6.0",
+]
+
+[[package]]
+name = "idna"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -1128,6 +1187,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "iovec"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1165,6 +1233,12 @@ checksum = "5cfb73131c35423a367daf8cbd24100af0d077668c8c2943f0e7dd775fef0f65"
 dependencies = [
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "language-tags"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 
 [[package]]
 name = "lazy_static"
@@ -1275,7 +1349,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212"
 dependencies = [
  "mime",
- "unicase",
+ "unicase 2.6.0",
 ]
 
 [[package]]
@@ -1389,6 +1463,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "oci-distribution"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d28926bb291150df3e09d0962836b03e9c20fb21d8a172023c5e42650ff16647"
+dependencies = [
+ "anyhow",
+ "futures-util",
+ "hyperx",
+ "lazy_static",
+ "regex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tokio",
+ "tracing",
+ "www-authenticate",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1469,6 +1563,12 @@ name = "paste"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5d65c4d95931acda4498f675e332fcbdc9a06705cd07086c510e9b6009cd1c1"
+
+[[package]]
+name = "percent-encoding"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 
 [[package]]
 name = "percent-encoding"
@@ -1818,7 +1918,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "http",
+ "http 0.2.1",
  "http-body",
  "hyper",
  "hyper-tls",
@@ -1828,14 +1928,14 @@ dependencies = [
  "log",
  "mime",
  "native-tls",
- "percent-encoding",
+ "percent-encoding 2.1.0",
  "pin-project-lite 0.2.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
- "url",
+ "url 2.2.1",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -2457,13 +2557,13 @@ dependencies = [
  "base64 0.13.0",
  "byteorder",
  "bytes 1.0.1",
- "http",
+ "http 0.2.1",
  "httparse",
  "input_buffer",
  "log",
  "rand 0.8.3",
  "sha-1 0.9.4",
- "url",
+ "url 2.2.1",
  "utf-8",
 ]
 
@@ -2490,11 +2590,20 @@ checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicase"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
+dependencies = [
+ "version_check 0.1.5",
+]
+
+[[package]]
+name = "unicase"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
 dependencies = [
- "version_check",
+ "version_check 0.9.2",
 ]
 
 [[package]]
@@ -2551,14 +2660,25 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
+dependencies = [
+ "idna 0.1.5",
+ "matches",
+ "percent-encoding 1.0.1",
+]
+
+[[package]]
+name = "url"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b"
 dependencies = [
  "form_urlencoded",
- "idna",
+ "idna 0.2.2",
  "matches",
- "percent-encoding",
+ "percent-encoding 2.1.0",
 ]
 
 [[package]]
@@ -2581,6 +2701,12 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
+
+[[package]]
+name = "version_check"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
@@ -2597,11 +2723,12 @@ dependencies = [
  "futures",
  "hyper",
  "log",
+ "oci-distribution",
  "serde",
  "tempfile",
  "tokio",
  "toml",
- "url",
+ "url 2.2.1",
  "wasi-cap-std-sync",
  "wasi-common",
  "wasi-experimental-http-wasmtime",
@@ -2629,13 +2756,13 @@ dependencies = [
  "bytes 1.0.1",
  "futures",
  "headers",
- "http",
+ "http 0.2.1",
  "hyper",
  "log",
  "mime",
  "mime_guess",
  "multipart",
- "percent-encoding",
+ "percent-encoding 2.1.0",
  "pin-project 1.0.4",
  "scoped-tls",
  "serde",
@@ -2710,7 +2837,7 @@ checksum = "7852d4aa0359e5b4875edd30a1d06eff36c0be62f26c6d6d75074cb236aede99"
 dependencies = [
  "anyhow",
  "bytes 1.0.1",
- "http",
+ "http 0.2.1",
  "tracing",
 ]
 
@@ -2723,11 +2850,11 @@ dependencies = [
  "anyhow",
  "bytes 1.0.1",
  "futures",
- "http",
+ "http 0.2.1",
  "reqwest",
  "tokio",
  "tracing",
- "url",
+ "url 2.2.1",
  "wasi-common",
  "wasi-experimental-http",
  "wasmtime",
@@ -3203,6 +3330,17 @@ dependencies = [
  "log",
  "thiserror",
  "wast 33.0.0",
+]
+
+[[package]]
+name = "www-authenticate"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c62efb8259cda4e4c732287397701237b78daa4c43edcf3e613c8503a6c07dd"
+dependencies = [
+ "hyperx",
+ "unicase 1.4.2",
+ "url 1.7.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2725,6 +2725,7 @@ dependencies = [
  "log",
  "oci-distribution",
  "serde",
+ "sha2",
  "tempfile",
  "tokio",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,9 @@ clap = "2.33.3"
 bindle = { version = "0.3", default-features = false, features = ["client", "server", "caching"] }
 url = "2.2"
 oci-distribution = "0.6"
+sha2 = "0.9"
+tempfile = "3.2"
 
 [dev-dependencies]
-tempfile = "3.2"
 bindle = "0.3"
 url = "2.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ wasi-experimental-http-wasmtime = "0.2"
 clap = "2.33.3"
 bindle = { version = "0.3", default-features = false, features = ["client", "server", "caching"] }
 url = "2.2"
+oci-distribution = "0.6"
 
 [dev-dependencies]
 tempfile = "3.2"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
-LOG_LEVEL ?= info
+LOG_LEVEL ?= info,wagi=debug
 MODULES_TOML ?= examples/modules.toml
+MODULE_CACHE ?= _scratch/cache
 
 .PHONY: build
 build:
@@ -7,7 +8,8 @@ build:
 
 .PHONY: run
 run:
-	RUST_LOG=$(LOG_LEVEL) cargo run --release -- -c $(MODULES_TOML)
+	mkdir -p $(MODULE_CACHE)
+	RUST_LOG=$(LOG_LEVEL) cargo run --release -- -c $(MODULES_TOML) --module-cache $(MODULE_CACHE)
 
 .PHONY: test
 test:

--- a/docs/configuring_and_running.md
+++ b/docs/configuring_and_running.md
@@ -35,7 +35,7 @@ In a nutshell, these are the fields that `modules.toml` supports.
   - `defaultDomain`: By default, WAGI answers only to the hostname `localhost`. This allows you to specify a different default domain.
 - The `[[module]]` list: Each module starts with a `[[module]]` header. Inside of a module, the following fields are available:
   - `route` (REQUIRED): The path that is appended to the server URL to create a full URL (e.g. `/foo` becomes `https://example.com/foo`)
-  - `module` (REQUIRED): The absolute path to the module on the file system
+  - `module` (REQUIRED): A module reference. See Module References below.
   - `environment`: A list of string/string environment variable pairs.
   - `repository`: RESERVED for future use
   - `entrypoint` (default: `_start`): The name of the function within the module. This will directly execute that function. Most WASM/WASI implementations create a `_start` function by default. An example of a module that declares 3 entrypoints can be found [here](https://github.com/technosophos/hello-wagi).
@@ -60,7 +60,7 @@ Each `[[module]]` section in the `modules.toml` file is responsible for mapping 
 The two required directives for a module section are:
 
 - `route`: The path-portion of a URL
-- `module`: The path to the WebAssembly module to execute
+- `module`: A reference to the WebAssembly module to execute
 
 Routes are paths relative to the WAGI HTTP root. Assuming the routes above are running on a server whose domain is `example.com`:
 
@@ -68,9 +68,15 @@ Routes are paths relative to the WAGI HTTP root. Assuming the routes above are r
 - A route like `/hello` would handle traffic to `http://example.com/hello`
 - The route `/hello/...` is a special wildcard route that handles any traffic to `http://example.com/hello` or a subpath (like `http://example.com/hello/today/is/a/goo/day`)
 
-The `module` directive is a path to a `wasm` or `wat` file on the filesystem.
-We recommend using absolute paths.
-Relative paths will be resolved from the current working directory in which `wagi` was started.
+### Module References
+
+A module reference is a URL. There are three supported module reference schemes:
+
+- `file://`: A path to a `.wasm` or `.wat` file on the filesystem. We recommend using absolute paths beginning with `file://`. Right now, there is legacy support for absolute and relative paths without the `file://` prefix, but we discourge using that. Relative paths will be resolved from the current working directory in which `wagi` was started.
+- `bindle:`: A reference to a Bindle. This will be looked up in the configured Bindle server. Example: `bindle:example.com/foo/bar/1.2.3`.
+- `oci`: A reference to an OCI image in an OCI registry. Example: `oci:foo/bar:1.2.3` (equivalent to the Docker image `foo/bar:1.2.3`).
+
+> Note: Bindle URLs should not ever have a `//`. OCI URLs should use a `//` only if refering to a specific host, and may always omit `//` even if there is a reference to an external host.
 
 #### Volume Mounting
 

--- a/docs/configuring_and_running.md
+++ b/docs/configuring_and_running.md
@@ -73,10 +73,8 @@ Routes are paths relative to the WAGI HTTP root. Assuming the routes above are r
 A module reference is a URL. There are three supported module reference schemes:
 
 - `file://`: A path to a `.wasm` or `.wat` file on the filesystem. We recommend using absolute paths beginning with `file://`. Right now, there is legacy support for absolute and relative paths without the `file://` prefix, but we discourge using that. Relative paths will be resolved from the current working directory in which `wagi` was started.
-- `bindle:`: A reference to a Bindle. This will be looked up in the configured Bindle server. Example: `bindle:example.com/foo/bar/1.2.3`.
-- `oci`: A reference to an OCI image in an OCI registry. Example: `oci:foo/bar:1.2.3` (equivalent to the Docker image `foo/bar:1.2.3`).
-
-> Note: Bindle URLs should not ever have a `//`. OCI URLs should use a `//` only if refering to a specific host, and may always omit `//` even if there is a reference to an external host.
+- `bindle:`: A reference to a Bindle. This will be looked up in the configured Bindle server. Example: `bindle:example.com/foo/bar/1.2.3`. Bindle URLs do not ever have a `//` after `bindle:`.
+- `oci`: A reference to an OCI image in an OCI registry. Example: `oci:foo/bar:1.2.3` (equivalent to the Docker image `foo/bar:1.2.3`). OCI URLs should not need `//` after `oci://`.
 
 #### Volume Mounting
 

--- a/src/runtime/bindle.rs
+++ b/src/runtime/bindle.rs
@@ -8,7 +8,11 @@ const WASM_MEDIA_TYPE: &str = "application/wasm";
 ///
 /// TODO: this currently fetches the first application/wasm condition-less parcel from the bindle and tries
 /// to load it.
-pub(crate) async fn load_bindle(server: &str, uri: &Url) -> anyhow::Result<wasmtime::Module> {
+pub(crate) async fn load_bindle(
+    server: &str,
+    uri: &Url,
+    engine: &Engine,
+) -> anyhow::Result<wasmtime::Module> {
     let bindle_name = uri.path();
     let bindler = Client::new(server)?;
     let invoice = bindler.get_invoice(bindle_name).await?;
@@ -39,5 +43,5 @@ pub(crate) async fn load_bindle(server: &str, uri: &Url) -> anyhow::Result<wasmt
     let p = bindler
         .get_parcel(invoice.bindle.id, first.label.sha256.as_str())
         .await?;
-    Module::new(&Engine::default(), p)
+    Module::new(engine, p)
 }

--- a/src/runtime/bindle.rs
+++ b/src/runtime/bindle.rs
@@ -1,8 +1,18 @@
+use std::path::PathBuf;
+
 use bindle::{client::Client, Parcel};
+use sha2::{Digest, Sha256};
 use url::Url;
 use wasmtime::{Engine, Module};
 
 const WASM_MEDIA_TYPE: &str = "application/wasm";
+
+pub(crate) fn bindle_cache_key(uri: &Url) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(uri.path());
+    let result = hasher.finalize();
+    format!("{:x}", result)
+}
 
 /// Given a server and a URI, attempt to load the bindle identified in the URI.
 ///
@@ -12,6 +22,7 @@ pub(crate) async fn load_bindle(
     server: &str,
     uri: &Url,
     engine: &Engine,
+    cache: PathBuf,
 ) -> anyhow::Result<wasmtime::Module> {
     let bindle_name = uri.path();
     let bindler = Client::new(server)?;
@@ -41,7 +52,11 @@ pub(crate) async fn load_bindle(
     let first = to_fetch.get(0).unwrap();
 
     let p = bindler
-        .get_parcel(invoice.bindle.id, first.label.sha256.as_str())
+        .get_parcel(bindle_cache_key(uri), first.label.sha256.as_str())
         .await?;
+    tokio::fs::write(cache.join(invoice.bindle.id.to_string()), &p)
+        .await
+        .err()
+        .map(|e| log::warn!("Failed to cache bindle: {}", e));
     Module::new(engine, p)
 }


### PR DESCRIPTION
Adds a mapping from the scheme `oci:` to an OCI Distributions registry.

Closes #37

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>