### PR TITLE
Fix absolute paths with file scheme on Windows 

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,12 +11,15 @@ env:
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v2
     - name: Build
-      run: cargo build --verbose
+      run: cargo build
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2833,23 +2833,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasi-experimental-http"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "429ba9fb7e1b2774725a65a75c1064604cb96adf24d237ea29d232d06d4f1537"
-dependencies = [
- "anyhow",
- "bytes 1.0.1",
- "http 0.2.1",
- "thiserror",
- "tracing",
-]
-
-[[package]]
 name = "wasi-experimental-http-wasmtime"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e50642a210a70f0904a3feb311bdf9eace36477f25eeb721728428158af32b"
+checksum = "fd1cb05f410188e2f374e7b7c7bc6fdcc6ed4e0a3a2d3e133351e3e0ca0bc920"
 dependencies = [
  "anyhow",
  "bytes 1.0.1",
@@ -2861,7 +2848,6 @@ dependencies = [
  "tracing",
  "url 2.2.1",
  "wasi-common",
- "wasi-experimental-http",
  "wasmtime",
  "wasmtime-wasi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ wasmtime-cache = "0.26"
 wasi-common = "0.26"
 wasi-cap-std-sync = "0.26"
 cap-std = "0.13"
-wasi-experimental-http-wasmtime = "0.3"
+wasi-experimental-http-wasmtime = "0.4"
 clap = "2.33.3"
 bindle = { version = "0.3", default-features = false, features = ["client", "server", "caching"] }
 url = "2.2"

--- a/docs/configuring_and_running.md
+++ b/docs/configuring_and_running.md
@@ -91,7 +91,7 @@ Routes are paths relative to the WAGI HTTP root. Assuming the routes above are r
 
 A module reference is a URL. There are three supported module reference schemes:
 
-- `file://`: A path to a `.wasm` or `.wat` file on the filesystem. We recommend using absolute paths beginning with `file://`. Right now, there is legacy support for absolute and relative paths without the `file://` prefix, but we discourge using that. Relative paths will be resolved from the current working directory in which `wagi` was started.
+- `file://`: A path to a `.wasm` or `.wat` file on the filesystem. We recommend using absolute paths beginning with `file://`. Right now, there is legacy support for absolute and relative paths without the `file://` prefix (note that this is not working on Windows with absolute paths), but we discourage using that. Relative paths will be resolved from the current working directory in which `wagi` was started.
 - `bindle:`: A reference to a Bindle. This will be looked up in the configured Bindle server. Example: `bindle:example.com/foo/bar/1.2.3`. Bindle URLs do not ever have a `//` after `bindle:`.
 - `oci`: A reference to an OCI image in an OCI registry. Example: `oci:foo/bar:1.2.3` (equivalent to the Docker image `foo/bar:1.2.3`). OCI URLs should not need `//` after `oci://`.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -5,9 +5,10 @@ Currently there are no prebuilt binaries of WAGI. You will need to build your ow
 ## Prerequisites
 
 - Rust (a recent version. We suggest 1.47 or later)
-- A Linux/macOS/UNIX/WSL2 environment
+- A Linux/macOS/UNIX/WSL2/Windows environment
 
-WAGI is untested on Windows. If you try it out and have feedback for us, please file an issue.
+We recently started testing WAGI on Windows, so please file an issue if you 
+encounter any issues.
 
 ## Building
 

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -783,8 +783,6 @@ mod test {
     use crate::DEFAULT_HOST as LOCALHOST;
 
     use std::io::Write;
-    use std::path::Path;
-    use std::path::PathBuf;
     use tempfile::NamedTempFile;
 
     const ROUTES_WAT: &str = r#"

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -817,8 +817,7 @@ mod test {
     #[tokio::test]
     async fn load_routes_from_wasm() {
         let tf = write_temp_wat(ROUTES_WAT).expect("created tempfile");
-        let watfile = tf.path();
-        let urlish = format!("file:{}", watfile.to_string_lossy().to_string());
+        let urlish = format!("file:{}", tf.path().to_string_lossy());
 
         let cache = "cache.toml".to_string();
 
@@ -901,8 +900,7 @@ mod test {
     #[tokio::test]
     async fn should_override_default_domain() {
         let tf = write_temp_wat(ROUTES_WAT).expect("wrote tempfile");
-        let watfile = tf.path();
-        let urlish = format!("file:{}", watfile.to_string_lossy().to_string());
+        let urlish = format!("file:{}", tf.path().to_string_lossy());
 
         let cache = "cache.toml".to_string();
 
@@ -941,8 +939,7 @@ mod test {
     #[tokio::test]
     async fn should_parse_file_uri() {
         let tf = write_temp_wat(ROUTES_WAT).expect("wrote tempfile");
-        let watfile = tf.path();
-        let urlish = format!("file:{}", watfile.to_string_lossy().to_string());
+        let urlish = format!("file:{}", tf.path().to_string_lossy());
 
         let module = Module {
             route: "/base".to_string(),
@@ -971,8 +968,7 @@ mod test {
     async fn should_parse_file_with_all_the_windows_slashes() {
         env_logger::init();
         let tf = write_temp_wat(ROUTES_WAT).expect("wrote tempfile");
-        let watfile = tf.path();
-        let testcases = possible_slashes_for_paths(watfile.to_string_lossy().to_string());
+        let testcases = possible_slashes_for_paths(tf.path().to_string_lossy().to_string());
         for test in testcases {
             let module = Module {
                 route: "/base".to_string(),


### PR DESCRIPTION
This commit starts adding support for building and running WAGI on
Windows. Specifically, it:

- updates the wasi-experimental-http-wasmtime crate to v0.4, which now
compiles and runs on Windows
- handles absolute paths with file scheme when defining a module

Please note that at this time, absolute paths without the `file:` scheme
will cause an issue, something to keep in mind as we decide removing
the legacy support for scheme-less modules.

