### PR TITLE
Add X_RELATIVE_PATH environment variable

### DIFF
--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -5,27 +5,60 @@ Every time WAGI processes a request, it starts the module and injects environmen
 These are the environment variables set on every WAGI requests:
 
 ```bash
+# The name of the route that matched
 X_MATCHED_ROUTE="/envwasm"  # for example.com/envwasm
+# The value of the HTTP Accept header from the client. This could be empty.
 HTTP_ACCEPT="*/*"
+# The HTTP method (GET/POST/PUT/etc) sent by the client
 REQUEST_METHOD="GET"
+# The protocol that the server is using. Normally this is "http" or "https"
 SERVER_PROTOCOL="http"
+# The value of the HTTP User-Agent header. This could be empty.
 HTTP_USER_AGENT="curl/7.64.1"
+# If the client sent a body (in a POST/PUT), the value of the client's
+# Content-Type header is here. This could be empty, even on a POST/PUT/PATCH.
 CONTENT_TYPE=""             # Usually set on POST/PUT
+# The name of the module requested. In a Bindle, this is the parcel name.
 SCRIPT_NAME="/path/to/env_wagi.wasm"
+# The name of the server software and it's MAJOR version.
 SERVER_SOFTWARE="WAGI/1"
-SERVER_PORT="80"
+# The port upon which the server received its request
+SERVER_PORT="3000"
+# The host and port that the server answered to. This usually matches the HOST
+# header.
 SERVER_NAME="localhost:3000"
+# The auth type (e.g. basic/digest)
 AUTH_TYPE=""
+# The client's IP address
 REMOTE_ADDR="127.0.0.1"
+# The server's IP address
 REMOTE_HOST="127.0.0.1"
+# The path portion of the URL. E.g. http://example.com/envwasm becomes /envwasm
 PATH_INFO="/envwasm"
+# The client-supplied query string, E.g. http://example.com?foo=bar becomes ?foo=bar
 QUERY_STRING=""
+# Currently, this is always the same as PATH_INFO, but is supplied for compatibility with
+# the CGI specification. It is not recommended that you use this variable.
 PATH_TRANSLATED="/envwasm"
+# The length of the body sent by the client. This is >0 only if the client sends a
+# non-empty body.
 CONTENT_LENGTH="0"
+# The value of the client-supplied HOST header.
 HTTP_HOST="localhost:3000"
+# The version of CGI that this gateway implements. Wagi always returns CGI/1.1
 GATEWAY_INTERFACE="CGI/1.1"
+# If authentication was performed by Wagi and a username is discernable from that
+# authentication, then this value is set to the username.
 REMOTE_USER=""
+# The entire URL that the client sent. This is reconstructed, so parts of the URL
+# may have been normalized out. For example, if the client sends
+# http://localhost:3000/foo/../envwasm, it will be normalized to
+# http://localhost:3000/envwasm.
 X_FULL_URL="http://localhost:3000/envwasm"
+# If a route containing /... matches, this is the part that matched "...".
+# For example, if the route is "/static/..." and the request comes for "/static/icon.png",
+# this will contain "icon.png"
+X_RELATIVE_PATH=""    
 ```
 
 In addition, if a `[[module]]` section that matches the route also declares `environment` variables, those will be added.

--- a/docs/writing_modules.md
+++ b/docs/writing_modules.md
@@ -183,7 +183,11 @@ REQUEST_METHOD = GET
 REMOTE_HOST = localhost
 X_FULL_URL = http://foo.example.com/env?greet=matt&foo=bar
 QUERY_STRING = greet=matt&foo=bar
+X_RELATIVE_PATH = ""
 ```
+
+See the [Environment Variables Reference](environment_variables.md) for a description of
+each environment variable.
 
 Most languages provide a convenient way to access environment variables.
 WASI provides an implementation of this OS facility (Which is why we require `wasm32-wasi` as the compile target).

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1036,6 +1036,14 @@ mod test {
 
         m.route = "/".to_owned();
         assert_eq!("", m.x_relative_path("/"));
+
+        // As a degenerate case, if the path does not match the prefix,
+        // then it should return an empty path because this is not
+        // a relative path from the given path. While this is a no-op in
+        // current Wagi, conceivably we could some day have to alter this
+        // behavior. So this test is a canary for a breaking change.
+        m.route = "/foo".to_owned();
+        assert_eq!("", m.x_relative_path("/bar"));
     }
 
     #[tokio::test]

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -392,6 +392,14 @@ impl Module {
         headers.insert("X_MATCHED_ROUTE".to_owned(), self.route.to_owned()); // Specific to WAGI (not CGI)
         headers.insert("PATH_INFO".to_owned(), req.uri.path().to_owned()); // TODO: Does this get trimmed?
 
+        // This also does not appear in the specification for CGI (largely because CGI did
+        // not necessarily "know about" URL rewrites). But it is very useful when combined
+        // with wildcard pattern matching.
+        headers.insert(
+            "X_RELATIVE_PATH".to_owned(),
+            self.x_relative_path(req.uri.path()),
+        );
+
         // NOTE: The security model of WAGI means that we do not give the actual
         // translated path on the host filesystem, as that is off limits to the runtime.
         // Right now, this just returns the same as PATH_INFO, but we could attempt to
@@ -449,6 +457,26 @@ impl Module {
         });
 
         headers
+    }
+
+    /// Resolve a relative path from the end of the matched path to the end of the string.
+    ///
+    /// For example, if the match is `/foo/...` and the path is `/foo/bar`, it should return `"bar"`,
+    /// but if the match is `/foo/bar` and the path is `/foo/bar`, it should return `""`.
+    fn x_relative_path(&self, uri_path: &str) -> String {
+        uri_path
+            .strip_prefix(
+                // Chop the `/...` off of the end if there is one.
+                self.route
+                    .strip_suffix("/...")
+                    .unwrap_or_else(|| self.route.as_str()),
+            )
+            // Remove a leading `/` if there is one.
+            .map(|r| r.strip_prefix("/").unwrap_or(r))
+            // It is possible that a root path request matching /... returns a None here,
+            // so in that case the appropriate return is "".
+            .unwrap_or("")
+            .to_owned()
     }
 
     // Load and execute the WASM module.
@@ -983,6 +1011,31 @@ mod test {
         // This should pass
         mc.handler_for_host_path(LOCALHOST, "/another/path")
             .expect("The generic handler should have been returned for this");
+    }
+
+    #[test]
+    fn should_produce_relative_path() {
+        let uri_path = "/static/images/icon.png";
+        let mut m = Module {
+            route: "/static/...".to_owned(),
+            module: "/tmp/fake".to_owned(),
+            volumes: None,
+            environment: None,
+            entrypoint: None,
+            host: None,
+            bindle_server: None,
+            allowed_hosts: None,
+        };
+        assert_eq!("images/icon.png", m.x_relative_path(uri_path.clone()));
+
+        m.route = "/static/images/icon.png".to_owned();
+        assert_eq!("", m.x_relative_path(uri_path));
+
+        m.route = "/...".to_owned();
+        assert_eq!("", m.x_relative_path("/"));
+
+        m.route = "/".to_owned();
+        assert_eq!("", m.x_relative_path("/"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
This adds an `X_RELATIVE_PATH` variable that contains the information matched in the `...` of a wildcard route.

For example, if the route `/static/...` matches the incoming URL `http://example.com/static/images/logo.png`, then the `X_RELATIVE_PATH` will be set to `images/logo.png`.

This is a common need for guest modules that use wildcard route matches. Calculating this on the host side removes the need for doing so in the guest side, and since this could conceivably be a security-sensitive operation, this reduces guest-side risk. Furthermore, it does not require guest modules to understand how the wildcard matching works. This should reduce future compatibility problems should we at some point change the wildcard matching logic.

Closes #57 