### PR TITLE
feat(*): Adds global environment variables to all modules

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,7 +170,7 @@ impl RouterBuilder {
     }
 
     /// Build the router, loading the config from a toml file at the given path
-    pub async fn build_modules_toml(self, path: impl AsRef<Path>) -> anyhow::Result<Router> {
+    pub async fn build_from_modules_toml(self, path: impl AsRef<Path>) -> anyhow::Result<Router> {
         if !tokio::fs::metadata(&path)
             .await
             .map(|m| m.is_file())
@@ -198,7 +198,11 @@ impl RouterBuilder {
 
     /// Build the router, loading the config from a bindle with the given name fetched from the
     /// provided server
-    pub async fn build_bindle(self, name: &str, bindle_server: &str) -> anyhow::Result<Router> {
+    pub async fn build_from_bindle(
+        self,
+        name: &str,
+        bindle_server: &str,
+    ) -> anyhow::Result<Router> {
         log::info!("Loading bindle {}", name);
         let cache_dir = self.module_cache_dir.join("_ASSETS");
         let mut mods = runtime::bindle::bindle_to_modules(name, bindle_server, cache_dir)

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use hyper::{
     server::conn::AddrStream,
     service::{make_service_fn, service_fn},
 };
+use std::collections::HashMap;
 use std::net::SocketAddr;
 use wagi::Router;
 
@@ -21,6 +22,8 @@ terminated as soon as it has returned the response.
 Wagi provides a few ways of speeding up performance. The easiest way is to enable a
 cache, which will cause all modules to be preloaded and cached on startup.
 "#;
+
+const ENV_VAR_HELP: &str = "specifies an environment variable that should be used for every module WAGI runs. These will override any set by the module config. Multiple environment variables can be set per flag (e.g. -e FOO=bar BAR=baz) or the flag can be used multiple times (e.g. `-e FOO=bar -e BAR=baz`). Variables can be quoted (e.g. FOO=\"my bar\")";
 
 #[tokio::main]
 pub async fn main() -> Result<(), anyhow::Error> {
@@ -87,6 +90,15 @@ pub async fn main() -> Result<(), anyhow::Error> {
                 .help("the path to a directory where module logs should be stored. This directory will have a separate subdirectory created within it per running module. Default is to create a tempdir.")
                 .takes_value(true),
         )
+        .arg(
+            Arg::with_name("env_vars")
+            .long("env")
+            .short("e")
+            .value_name("ENV_VARS")
+            .help(ENV_VAR_HELP)
+            .takes_value(true)
+            .multiple(true)
+        )
         .get_matches();
 
     let addr: SocketAddr = matches
@@ -96,6 +108,8 @@ pub async fn main() -> Result<(), anyhow::Error> {
         .unwrap();
 
     log::info!("=> Starting server on {}", addr.to_string());
+
+    let builder = Router::builder();
 
     // We have to pass a cache file configuration path to a Wasmtime engine.
     let cache_config_path = matches.value_of("cache").unwrap_or("cache.toml").to_owned();
@@ -110,10 +124,7 @@ pub async fn main() -> Result<(), anyhow::Error> {
         .to_owned();
     let bindle = matches.value_of("bindle");
 
-    let default_host = matches
-        .value_of("default_host")
-        .unwrap_or("localhost:3000")
-        .to_owned();
+    let default_host = matches.value_of("default_host").unwrap_or("localhost:3000");
 
     let mc = match matches.value_of("module_cache") {
         Some(m) => std::path::PathBuf::from(m),
@@ -132,33 +143,25 @@ pub async fn main() -> Result<(), anyhow::Error> {
         }
     };
 
-    let mut module_config = match bindle {
-        Some(name) => wagi::load_bindle(
-            name,
-            bindle_server.as_str(),
-            cache_config_path.clone(),
-            mc.clone(),
-            &log_dir,
-        )
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to load bindle {}: {}", name, e))?,
-        None => wagi::load_modules_toml(
-            module_config_path.as_str(),
-            cache_config_path.clone(),
-            mc.clone(),
-            &log_dir,
-        )
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to load TOML {}: {}", module_config_path, e))?,
+    let env_vars: HashMap<String, String> = match matches.values_of("env_vars") {
+        Some(v) => v
+            .into_iter()
+            .map(parse_env_var)
+            .collect::<anyhow::Result<_>>()?,
+        None => HashMap::new(),
     };
 
-    if module_config.default_host.is_none() {
-        log::info!("Setting default host to {}", default_host.as_str());
-        module_config.default_host = Some(default_host);
-    }
+    let builder = builder
+        .cache_config_path(cache_config_path)
+        .module_cache_dir(mc)
+        .base_log_dir(log_dir)
+        .default_host(default_host)
+        .global_env_vars(env_vars);
 
-    //debug!("Module Config\n {:#?}", module_config);
-    let router = Router::new(module_config, cache_config_path, mc, log_dir).await?;
+    let router = match bindle {
+        Some(name) => builder.build_bindle(name, &bindle_server).await?,
+        None => builder.build_modules_toml(&module_config_path).await?,
+    };
 
     let mk_svc = make_service_fn(move |conn: &AddrStream| {
         let addr = conn.remote_addr();
@@ -177,4 +180,94 @@ pub async fn main() -> Result<(), anyhow::Error> {
         log::error!("server error: {}", e);
     }
     Ok(())
+}
+
+fn parse_env_var(val: &str) -> anyhow::Result<(String, String)> {
+    let (key, value) = val
+        .split_once('=')
+        .ok_or_else(|| anyhow::anyhow!("Invalid environment variable, did not find '='"))?;
+
+    // Check if the key is empty (i.e. the user set -e =bar). An environment variable must have a
+    // key, but can have an empty value
+    if key.is_empty() {
+        return Err(anyhow::anyhow!(
+            "Environment variable must have a non-empty key"
+        ));
+    }
+
+    // If the value starts and ends with a double or single quote, assume it is a quoted value and
+    // strip the quotes
+    let final_value = if value.starts_with('"') && value.ends_with('"') {
+        value.trim_matches('"').to_owned()
+    } else if value.starts_with('\'') && value.ends_with('\'') {
+        value.trim_matches('\'').to_owned()
+    } else {
+        value.to_owned()
+    };
+
+    Ok((key.to_owned(), final_value))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_successful_env_var_parse() {
+        parse_env_var("FOO=bar").expect("Normal env var pair should parse");
+
+        parse_env_var("FOO=").expect("No value should parse");
+
+        let (_, value) = parse_env_var("FOO=\"bar -s\"").expect("Double quoted value should parse");
+        assert!(
+            !value.contains('"'),
+            "Double quoted value should have quotes removed"
+        );
+
+        let (_, value) = parse_env_var("FOO='bar -s'").expect("Single quoted value should parse");
+        assert!(
+            !value.contains('\''),
+            "Single quoted value should have quotes removed"
+        );
+
+        let (_, value) =
+            parse_env_var("FOO=\"bar \" -s\"").expect("Non-matching double quote should parse");
+        assert!(
+            value.match_indices('"').count() == 1,
+            "Value with double quote should not have quote removed"
+        );
+
+        let (_, value) =
+            parse_env_var("FOO=bar\"").expect("Non-matching double quote should parse (case 2)");
+        assert!(
+            value.match_indices('"').count() == 1,
+            "Value with double quote should not have quote removed (case 2)"
+        );
+
+        let (_, value) =
+            parse_env_var("FOO='bar ' -s'").expect("Non-matching single quote should parse");
+        assert!(
+            value.match_indices('\'').count() == 1,
+            "Value with double quote should not have quote removed"
+        );
+
+        let (_, value) = parse_env_var("FOO=\"\"").expect("Empty double quoted value should parse");
+        assert!(
+            value.is_empty(),
+            "Empty double quoted value should be empty"
+        );
+
+        let (_, value) = parse_env_var("FOO=''").expect("Empty single quoted value should parse");
+        assert!(
+            value.is_empty(),
+            "Empty single quoted value should be empty"
+        );
+    }
+
+    #[test]
+    fn test_unsuccessful_env_var_parse() {
+        parse_env_var("FOO").expect_err("Missing '=' should fail");
+
+        parse_env_var("=bar").expect_err("Missing key should fail");
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -157,8 +157,8 @@ pub async fn main() -> Result<(), anyhow::Error> {
         .global_env_vars(env_vars);
 
     let router = match bindle {
-        Some(name) => builder.build_bindle(name, &bindle_server).await?,
-        None => builder.build_modules_toml(&module_config_path).await?,
+        Some(name) => builder.build_from_bindle(name, &bindle_server).await?,
+        None => builder.build_from_modules_toml(&module_config_path).await?,
     };
 
     let mk_svc = make_service_fn(move |conn: &AddrStream| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,8 +109,6 @@ pub async fn main() -> Result<(), anyhow::Error> {
 
     log::info!("=> Starting server on {}", addr.to_string());
 
-    let builder = Router::builder();
-
     // We have to pass a cache file configuration path to a Wasmtime engine.
     let cache_config_path = matches.value_of("cache").unwrap_or("cache.toml").to_owned();
     let module_config_path = matches
@@ -151,7 +149,7 @@ pub async fn main() -> Result<(), anyhow::Error> {
         None => HashMap::new(),
     };
 
-    let builder = builder
+    let builder = Router::builder()
         .cache_config_path(cache_config_path)
         .module_cache_dir(mc)
         .base_log_dir(log_dir)

--- a/src/runtime/bindle.rs
+++ b/src/runtime/bindle.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashMap, path::PathBuf};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
 
 use bindle::{client::Client, Id, Invoice, Parcel};
 use indexmap::IndexSet;
@@ -25,7 +28,7 @@ pub(crate) async fn load_bindle(
     server: &str,
     uri: &Url,
     engine: &wasmtime::Engine,
-    cache: PathBuf,
+    cache: &Path,
 ) -> anyhow::Result<wasmtime::Module> {
     let bindle_name = uri.path();
 
@@ -111,7 +114,7 @@ pub async fn load_parcel(
     server: &str,
     uri: &Url,
     engine: &wasmtime::Engine,
-    cache: PathBuf,
+    cache: &Path,
 ) -> anyhow::Result<wasmtime::Module> {
     let bindler = Client::new(server)?;
     let parcel_sha = uri.fragment();
@@ -194,7 +197,7 @@ pub async fn cache_parcel_asset(
 }
 
 /// Fetch a bindle and convert it to a module configuration.
-pub async fn bindle_to_modules(
+pub(crate) async fn bindle_to_modules(
     name: &str,
     server_url: &str,
     asset_cache: PathBuf,


### PR DESCRIPTION
This PR adds support for environment variables set on the command line that
are then inserted into all running modules.

As part of this, I did a refactor around how a `Router` is constructed. We were
passing all sorts of parameters around and duplicating data in several structs.
I would have had to add yet another parameter to pass things down the chain or
would have been manually modifying data after loading. All of this has now been
rolled into the new `RouterBuilder` that follows the builder pattern for
configuring a new `Router`. Still isn't perfect and there are some weird clones,
but now the top level API is a bit easier to use.

Closes #63