### PR TITLE
Bump minimum required version of rust

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,7 @@ Currently there are no prebuilt binaries of WAGI. You will need to build your ow
 
 ## Prerequisites
 
-- Rust (a recent version. We suggest 1.47 or later)
+- Rust (a recent version. We suggest 1.52 or later)
 - A Linux/macOS/UNIX/WSL2/Windows environment
 
 We recently started testing WAGI on Windows, so please file an issue if you 


### PR DESCRIPTION
We are using new features that were introduced in very recent versions of rust, for example split_once was added in 1.52. This bumps the minimum version of rust listed in the installation guide to the most recent stable build.