### PR TITLE
feat(*): Adds optional TLS support to the server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,6 +73,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
 
 [[package]]
+name = "async-stream"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171374e7e3b2504e0e5236e3b59260560f9fe94bfe9ac39ba5e4e929c5590625"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "648ed8c8d2ce5409ccd57453d9d1b214b342a0d69376a6feda1fd6cae3299308"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2730,6 +2751,7 @@ name = "wagi"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-stream",
  "async-trait",
  "bindle",
  "cap-std",
@@ -2744,6 +2766,7 @@ dependencies = [
  "sha2",
  "tempfile",
  "tokio",
+ "tokio-rustls",
  "toml",
  "url 2.2.1",
  "wasi-cap-std-sync",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,9 @@ tempfile = "3.2"
 wat = "1.0.37"
 async-trait = "0.1"
 indexmap = { version = "^1.6.2", features = ["serde"] }
+async-stream = "0.3"
+# This re-exports rustls, so we don't need to import it separately
+tokio-rustls = "0.22"
 
 [dev-dependencies]
 bindle = "0.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,20 +95,20 @@ pub async fn main() -> Result<(), anyhow::Error> {
                 .takes_value(true),
         )
         .arg(
-            Arg::with_name("cert_file")
-                .long("cert-file")
-                .value_name("CERT_FILE")
+            Arg::with_name("tls_cert_file")
+                .long("tls-cert-file")
+                .value_name("TLS_CERT_FILE")
                 .takes_value(true)
                 .help("the path to the certificate to use for https, if this is not set, normal http will be used. The cert should be in PEM format")
-                .requires("key_file")
+                .requires("tls_key_file")
         )
         .arg(
-            Arg::with_name("key_file")
-                .long("key-file")
-                .value_name("KEY_FILE")
+            Arg::with_name("tls_key_file")
+                .long("tls-key-file")
+                .value_name("TLS_KEY_FILE")
                 .takes_value(true)
                 .help("the path to the certificate key to use for https, if this is not set, normal http will be used. The key should be in PKCS#8 format")
-                .requires("cert_file")
+                .requires("tls_cert_file")
         )
         .arg(
             Arg::with_name("env_vars")
@@ -183,9 +183,12 @@ pub async fn main() -> Result<(), anyhow::Error> {
 
     // NOTE(thomastaylor312): I apologize for the duplicated code here. I tried to work around this
     // by creating a GetRemoteAddr trait, but you can't use an impl Trait in a closure. The return
-    // types for the service fns aren't exported and so I could do a wrapper around the router
+    // types for the service fns aren't exported and so I couldn't do a wrapper around the router
     // either. This means these services are basically the same, but with different connection types
-    match (matches.value_of("cert_file"), matches.value_of("key_file")) {
+    match (
+        matches.value_of("tls_cert_file"),
+        matches.value_of("tls_key_file"),
+    ) {
         (Some(cert), Some(key)) => {
             let mk_svc = make_service_fn(move |conn: &TlsStream<TcpStream>| {
                 let (inner, _) = conn.get_ref();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,15 @@
+mod tls;
+
 use clap::{App, Arg};
-use hyper::Server;
 use hyper::{
     server::conn::AddrStream,
     service::{make_service_fn, service_fn},
 };
+use hyper::{Body, Response, Server};
 use std::collections::HashMap;
 use std::net::SocketAddr;
+use tokio::net::TcpStream;
+use tokio_rustls::server::TlsStream;
 use wagi::Router;
 
 const ABOUT: &str = r#"
@@ -91,6 +95,22 @@ pub async fn main() -> Result<(), anyhow::Error> {
                 .takes_value(true),
         )
         .arg(
+            Arg::with_name("cert_file")
+                .long("cert-file")
+                .value_name("CERT_FILE")
+                .takes_value(true)
+                .help("the path to the certificate to use for https, if this is not set, normal http will be used. The cert should be in PEM format")
+                .requires("key_file")
+        )
+        .arg(
+            Arg::with_name("key_file")
+                .long("key-file")
+                .value_name("KEY_FILE")
+                .takes_value(true)
+                .help("the path to the certificate key to use for https, if this is not set, normal http will be used. The key should be in PKCS#8 format")
+                .requires("cert_file")
+        )
+        .arg(
             Arg::with_name("env_vars")
             .long("env")
             .short("e")
@@ -161,22 +181,64 @@ pub async fn main() -> Result<(), anyhow::Error> {
         None => builder.build_from_modules_toml(&module_config_path).await?,
     };
 
-    let mk_svc = make_service_fn(move |conn: &AddrStream| {
-        let addr = conn.remote_addr();
-        let r = router.clone();
-        async move {
-            Ok::<_, std::convert::Infallible>(service_fn(move |req| {
-                let r2 = r.clone();
-                async move { r2.route(req, addr).await }
-            }))
+    // NOTE(thomastaylor312): I apologize for the duplicated code here. I tried to work around this
+    // by creating a GetRemoteAddr trait, but you can't use an impl Trait in a closure. The return
+    // types for the service fns aren't exported and so I could do a wrapper around the router
+    // either. This means these services are basically the same, but with different connection types
+    match (matches.value_of("cert_file"), matches.value_of("key_file")) {
+        (Some(cert), Some(key)) => {
+            let mk_svc = make_service_fn(move |conn: &TlsStream<TcpStream>| {
+                let (inner, _) = conn.get_ref();
+                // We are mapping the error because the normal error types are not cloneable and
+                // service functions do not like captured vars, even when moved
+                let addr_res = inner.peer_addr().map_err(|e| e.to_string());
+                let r = router.clone();
+                Box::pin(async move {
+                    Ok::<_, std::convert::Infallible>(service_fn(move |req| {
+                        let r2 = r.clone();
+                        // NOTE: There isn't much in the way of error handling we can do here as
+                        // this function needs to return an infallible future. Based on the
+                        // documentation of the underlying getpeername function
+                        // (https://man7.org/linux/man-pages/man2/getpeername.2.html and
+                        // https://docs.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getpeername)
+                        // the only error that will probably occur here is an interrupted connection
+                        let a_res = addr_res.clone();
+                        async move {
+                            match a_res {
+                                Ok(addr) => r2.route(req, addr).await,
+                                Err(e) => {
+                                    log::error!("Socket connection error on new connection: {}", e);
+                                    Ok(Response::builder()
+                                        .status(hyper::http::StatusCode::INTERNAL_SERVER_ERROR)
+                                        .body(Body::from("Socket connection error"))
+                                        .unwrap())
+                                }
+                            }
+                        }
+                    }))
+                })
+            });
+            Server::builder(tls::TlsHyperAcceptor::new(&addr, cert, key).await?)
+                .serve(mk_svc)
+                .await?;
         }
-    });
-
-    let srv = Server::bind(&addr).serve(mk_svc);
-
-    if let Err(e) = srv.await {
-        log::error!("server error: {}", e);
+        (None, None) => {
+            let mk_svc = make_service_fn(move |conn: &AddrStream| {
+                let addr = conn.remote_addr();
+                let r = router.clone();
+                async move {
+                    Ok::<_, std::convert::Infallible>(service_fn(move |req| {
+                        let r2 = r.clone();
+                        async move { r2.route(req, addr).await }
+                    }))
+                }
+            });
+            Server::bind(&addr).serve(mk_svc).await?;
+        }
+        // Shouldn't get here, but just in case, print a helpful warning
+        _ => anyhow::bail!("Both a cert and key file should be set or neither should be set"),
     }
+
     Ok(())
 }
 

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -1,0 +1,145 @@
+// Simple HTTPS echo service based on hyper-rustls, borrowed and modified from
+// https://github.com/rustls/hyper-rustls/blob/3f16ac4c36d1133883073b7d6eacf8c09339e87f/examples/server.rs
+//
+// Note: We may want to make this our own little crate we share with the world if we end up using
+// this in more than one place. As far as I can tell, there are no "TlsAcceptor" crates available
+// out there
+use core::task::{Context, Poll};
+use std::future::Future;
+use std::path::Path;
+use std::pin::Pin;
+use std::vec::Vec;
+use std::{fs, io, sync::Arc};
+use tokio::net::{TcpListener, TcpStream, ToSocketAddrs};
+use tokio_rustls::rustls::internal::pemfile;
+use tokio_rustls::rustls::{self, ServerConfig};
+use tokio_rustls::server::TlsStream;
+use tokio_rustls::{Accept, TlsAcceptor};
+
+fn error(err: String) -> io::Error {
+    io::Error::new(io::ErrorKind::Other, err)
+}
+
+pub(crate) struct TlsHyperAcceptor {
+    listener: TcpListener,
+    acceptor: TlsAcceptor,
+    in_progress_stream: Option<Accept<TcpStream>>,
+}
+
+impl TlsHyperAcceptor {
+    pub(crate) async fn new(
+        addr: impl ToSocketAddrs,
+        cert_file: impl AsRef<Path>,
+        key_file: impl AsRef<Path>,
+    ) -> io::Result<Self> {
+        let listener = TcpListener::bind(addr).await?;
+        let tls_cfg = {
+            // Load public certificate.
+            let certs = load_certs(cert_file)?;
+            // Load private key.
+            let key = load_private_key(key_file)?;
+            // Do not use client certificate authentication.
+            let mut cfg = ServerConfig::new(rustls::NoClientAuth::new());
+            // Select a certificate to use.
+            cfg.set_single_cert(certs, key)
+                .map_err(|e| error(format!("{}", e)))?;
+            // Configure ALPN to accept HTTP/1.1 (and not http2 due differences in header
+            // requirements, namely the HOST header). If we want to add http2 in the future, we can
+            // add `b"h2".to_vec()` to the list
+            cfg.set_protocols(&[b"http/1.1".to_vec()]);
+            Arc::new(cfg)
+        };
+        Ok(TlsHyperAcceptor {
+            listener,
+            acceptor: tls_cfg.into(),
+            in_progress_stream: None,
+        })
+    }
+}
+
+impl hyper::server::accept::Accept for TlsHyperAcceptor {
+    type Conn = TlsStream<TcpStream>;
+    type Error = io::Error;
+
+    fn poll_accept(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context,
+    ) -> Poll<Option<Result<Self::Conn, Self::Error>>> {
+        let mut accept = match self.in_progress_stream.take() {
+            Some(s) => {
+                log::trace!("TLS handshake currently in progress. Polling for current status");
+                s
+            }
+            None => {
+                log::trace!("No handshake in progress, checking for new connection");
+                let socket = match Pin::new(&mut self.listener).poll_accept(cx) {
+                    Poll::Ready(Ok((socket, _))) => socket,
+                    Poll::Ready(Err(e)) => return Poll::Ready(Some(Err(e))),
+                    Poll::Pending => return Poll::Pending,
+                };
+                self.acceptor.accept(socket)
+            }
+        };
+
+        match Pin::new(&mut accept).poll(cx) {
+            Poll::Ready(Ok(i)) => {
+                log::trace!("TLS handshake complete, returning active connection");
+                Poll::Ready(Some(Ok(i)))
+            }
+            // Based on my testing, it seems like when someone passes an invalid certificate or you
+            // try to make an http request to this endpoint, the error is always invalid data.
+            // Perhaps we can eventually just swallow all errors, but this seems to be the most
+            // common one
+            Poll::Ready(Err(e)) if matches!(e.kind(), std::io::ErrorKind::InvalidData) => {
+                log::trace!("Got invalid https request: {:?}", e);
+                // We are explicitly not setting the in_progress_stream because there is nothing
+                // more we can do with this connection as it is invalid. Wake the task so it can
+                // poll for a new connection
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            }
+            Poll::Ready(Err(e)) => Poll::Ready(Some(Err(e))),
+            Poll::Pending => {
+                self.in_progress_stream = Some(accept);
+                Poll::Pending
+            }
+        }
+    }
+}
+
+// Load public certificate from file.
+fn load_certs(filename: impl AsRef<Path>) -> io::Result<Vec<rustls::Certificate>> {
+    // Open certificate file.
+    let certfile = fs::File::open(&filename).map_err(|e| {
+        error(format!(
+            "failed to open {}: {}",
+            filename.as_ref().display(),
+            e
+        ))
+    })?;
+    let mut reader = io::BufReader::new(certfile);
+
+    // Load and return certificate.
+    pemfile::certs(&mut reader).map_err(|_| error("failed to load certificate".into()))
+}
+
+// Load private key from file.
+fn load_private_key(filename: impl AsRef<Path>) -> io::Result<rustls::PrivateKey> {
+    // Open keyfile.
+    let keyfile = fs::File::open(&filename).map_err(|e| {
+        error(format!(
+            "failed to open {}: {}",
+            filename.as_ref().display(),
+            e
+        ))
+    })?;
+    let mut reader = io::BufReader::new(keyfile);
+
+    // Load and return a single private key.
+    let keys = pemfile::pkcs8_private_keys(&mut reader)
+        .map_err(|_| error("failed to load private key".into()))?;
+    if keys.len() != 1 {
+        return Err(error("expected a single private key".into()));
+    }
+    Ok(keys[0].clone())
+}

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -43,7 +43,7 @@ impl TlsHyperAcceptor {
             // Select a certificate to use.
             cfg.set_single_cert(certs, key)
                 .map_err(|e| error(format!("{}", e)))?;
-            // Configure ALPN to accept HTTP/1.1 (and not http2 due differences in header
+            // Configure ALPN to accept HTTP/1.1 (and not http2 due to differences in header
             // requirements, namely the HOST header). If we want to add http2 in the future, we can
             // add `b"h2".to_vec()` to the list
             cfg.set_protocols(&[b"http/1.1".to_vec()]);


### PR DESCRIPTION
So it turns out there isn't much in the way of low level TLS support for servers.
Pretty much everyone has implemented something similar. I think I cover most of
the cases here, but please be diligent in your review. As noted in the code, it
may be worth our time to release the `TlsAcceptor` stuff as public crate, but
obviously that is outside the scope of this PR.

Closes #67