### PR TITLE
fix flag typo: --hostname

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -71,7 +71,7 @@ pub async fn main() -> Result<(), anyhow::Error> {
         )
         .arg(
             Arg::with_name("hostname")
-                .long("hostnam")
+                .long("hostname")
                 .value_name("HOSTNAME")
                 .takes_value(true)
                 .help("the hostname (and the port if not :80) that is to be considered the default. Default: localhost:3000"),


### PR DESCRIPTION
Old output:

```
bacongobbler@ultralisk ~/code/wagi ><> ./target/release/wagi --help
WAGI Server 0.1.0
DeisLabs

Run an HTTP WAGI server

This starts a Wagi server that either uses a config file or a bindle reference to mount routes.
It starts an HTTP server that listens on incoming requests, and then matches the request
route to a Wasm module.

The server runs for the duration of the process. But modules are executed on-demand
when Wagi handles a request. The module is started with the inbound request, and is
terminated as soon as it has returned the response.

Wagi provides a few ways of speeding up performance. The easiest way is to enable a
cache, which will cause all modules to be preloaded and cached on startup.

USAGE:
    wagi [OPTIONS]

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
    -b, --bindle <bindle>                      A bindle URL, such as bindle:foo/bar/1.2.3
        --bindle-server <BINDLE_SERVER_URL>    The Bindle server URL, e.g. https://example.com:8080/v1. Note that the
                                               version path (v1) is required.
        --cache <CACHE_TOML>                   the path to the cache.toml configuration file for configuring the Wasm
                                               optimization cache
    -c, --config <MODULES_TOML>                the path to the modules.toml configuration file
    -e, --env <ENV_VARS>...                    specifies an environment variable that should be used for every module
                                               WAGI runs. These will override any set by the module config. Multiple
                                               environment variables can be set per flag (e.g. -e FOO=bar BAR=baz) or
                                               the flag can be used multiple times (e.g. `-e FOO=bar -e BAR=baz`).
                                               Variables can be quoted (e.g. FOO="my bar")
        --hostnam <HOSTNAME>                   the hostname (and the port if not :80) that is to be considered the
                                               default. Default: localhost:3000
    -l, --listen <IP_PORT>                     the IP address and port to listen on. Default: 127.0.0.1:3000
        --log-dir <LOG_DIR>                    the path to a directory where module logs should be stored. This
                                               directory will have a separate subdirectory created within it per running
                                               module. Default is to create a tempdir.
        --module-cache <MODULE_CACHE_DIR>      the path to a directory where modules can be cached after fetching from
                                               remote locations. Default is to create a tempdir.
```