### PR TITLE
feat(make): Automatically generate cert on serve-tls target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,14 @@ build:
 
 .PHONY: serve
 serve: TLS_OPTS = 
-serve: serve-tls
+serve: _run
 
 .PHONY: serve-tls
-serve-tls:
+serve-tls: gen-cert
+serve-tls: _run
+
+.PHONY: _run
+_run:
 	mkdir -p $(MODULE_CACHE)
 	RUST_LOG=$(LOG_LEVEL) cargo run --release -- -c $(MODULES_TOML) --module-cache $(MODULE_CACHE) ${TLS_OPTS}
 
@@ -30,6 +34,7 @@ run-bindle:
 test:
 	cargo test
 
-.PHONY: gen-cert
-gen-cert:
-	openssl req -newkey rsa:2048 -nodes -keyout ${CERT_NAME}.key.pem -x509 -days 365 -out ${CERT_NAME}.crt.pem 
+gen-cert: ${CERT_NAME}.crt.pem
+
+${CERT_NAME}.crt.pem:
+	openssl req -newkey rsa:2048 -nodes -keyout ${CERT_NAME}.key.pem -x509 -days 365 -out ${CERT_NAME}.crt.pem

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -30,7 +30,7 @@ You can move the binary to any location you choose. Just make sure it has execut
 ## Running from Source
 
 If you prefer to run from source without building, you can use `make serve` (which runs `cargo run` with all the settings).
-You can test out SSL/TLS with `make gen-cert` to generate a testing certificate, and `make serve-tls` to serve with that certificate.
+You can test out SSL/TLS with `make serve-tls`, which will automatically generate a self-signed certificate for WAGI to use.
 
 > Note that if you are using a self-signed certificate, you will need to supply the `-k` flag to curl.
 


### PR DESCRIPTION
This leverages make to check if the file already exists and will only generate
the certificate if it doesn't already exist. This should make the whole
process a bit more seamless