### PR TITLE
Respect `--env` settings when serving from bindle

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,7 +215,7 @@ impl RouterBuilder {
         let invoice: Invoice = toml::from_slice(&data)?;
 
         let cache_dir = self.module_cache_dir.join("_ASSETS");
-        let mut mods = runtime::bindle::standalone_invoice_to_modules(&invoice, reader.parcel_dir, cache_dir)
+        let mut mods = runtime::bindle::standalone_invoice_to_modules(&invoice, reader.parcel_dir, cache_dir, &self.global_env_vars)
             .await
             .map_err(|e| {
                 anyhow::anyhow!("Failed to turn Bindle into module configuration: {}", e)
@@ -240,7 +240,7 @@ impl RouterBuilder {
     ) -> anyhow::Result<Router> {
         tracing::info!(name, "Loading bindle");
         let cache_dir = self.module_cache_dir.join("_ASSETS");
-        let mut mods = runtime::bindle::bindle_to_modules(name, bindle_server, cache_dir)
+        let mut mods = runtime::bindle::bindle_to_modules(name, bindle_server, cache_dir, &self.global_env_vars)
             .await
             .map_err(|e| {
                 anyhow::anyhow!("Failed to turn Bindle into module configuration: {}", e)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,11 +215,14 @@ impl RouterBuilder {
         let invoice: Invoice = toml::from_slice(&data)?;
 
         let cache_dir = self.module_cache_dir.join("_ASSETS");
-        let mut mods = runtime::bindle::standalone_invoice_to_modules(&invoice, reader.parcel_dir, cache_dir, &self.global_env_vars)
-            .await
-            .map_err(|e| {
-                anyhow::anyhow!("Failed to turn Bindle into module configuration: {}", e)
-            })?;
+        let mut mods = runtime::bindle::standalone_invoice_to_modules(
+            &invoice,
+            reader.parcel_dir,
+            cache_dir,
+            &self.global_env_vars,
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to turn Bindle into module configuration: {}", e))?;
 
         mods.build_registry(
             &self.cache_config_path,
@@ -240,11 +243,14 @@ impl RouterBuilder {
     ) -> anyhow::Result<Router> {
         tracing::info!(name, "Loading bindle");
         let cache_dir = self.module_cache_dir.join("_ASSETS");
-        let mut mods = runtime::bindle::bindle_to_modules(name, bindle_server, cache_dir, &self.global_env_vars)
-            .await
-            .map_err(|e| {
-                anyhow::anyhow!("Failed to turn Bindle into module configuration: {}", e)
-            })?;
+        let mut mods = runtime::bindle::bindle_to_modules(
+            name,
+            bindle_server,
+            cache_dir,
+            &self.global_env_vars,
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to turn Bindle into module configuration: {}", e))?;
 
         mods.build_registry(
             &self.cache_config_path,

--- a/src/runtime/bindle.rs
+++ b/src/runtime/bindle.rs
@@ -9,7 +9,7 @@ use sha2::{Digest, Sha256};
 use tracing::{debug, instrument, trace, warn};
 use url::Url;
 
-use crate::{ModuleConfig, runtime::Module};
+use crate::{runtime::Module, ModuleConfig};
 
 const WASM_MEDIA_TYPE: &str = "application/wasm";
 

--- a/src/runtime/bindle.rs
+++ b/src/runtime/bindle.rs
@@ -9,7 +9,7 @@ use sha2::{Digest, Sha256};
 use tracing::{debug, instrument, trace, warn};
 use url::Url;
 
-use crate::{runtime::Module, ModuleConfig};
+use crate::{ModuleConfig, runtime::Module};
 
 const WASM_MEDIA_TYPE: &str = "application/wasm";
 
@@ -250,11 +250,12 @@ pub(crate) async fn bindle_to_modules(
     name: &str,
     server_url: &str,
     asset_cache: PathBuf,
+    environment: &HashMap<String, String>,
 ) -> anyhow::Result<ModuleConfig> {
     let bindler = Client::new(server_url)?;
     let invoice = bindler.get_invoice(name).await?;
 
-    invoice_to_modules(&invoice, server_url, asset_cache).await
+    invoice_to_modules(&invoice, server_url, asset_cache, environment).await
 }
 
 /// Convenience function for generating an internal Parcel URL.
@@ -276,6 +277,7 @@ pub async fn standalone_invoice_to_modules(
     invoice: &Invoice,
     parcel_dir: PathBuf,
     asset_cache: PathBuf,
+    environment: &HashMap<String, String>,
 ) -> anyhow::Result<ModuleConfig> {
     let mut modules = IndexSet::new();
     let bindle_id = invoice.bindle.id.clone();
@@ -289,7 +291,7 @@ pub async fn standalone_invoice_to_modules(
 
     for parcel in top {
         // Create a basic module definition from the features section on this parcel.
-        let mut def = wagi_features(&invoice.bindle.id, &parcel);
+        let mut def = wagi_features(&invoice.bindle.id, &parcel, environment);
 
         def.module = parcel_dir
             .join(format!("{}.dat", parcel.label.sha256))
@@ -363,6 +365,7 @@ pub async fn invoice_to_modules(
     invoice: &Invoice,
     bindle_server: &str,
     asset_cache: PathBuf,
+    environment: &HashMap<String, String>,
 ) -> anyhow::Result<ModuleConfig> {
     let mut modules = IndexSet::new();
     let bindle_id = invoice.bindle.id.clone();
@@ -376,7 +379,7 @@ pub async fn invoice_to_modules(
 
     for parcel in top {
         // Create a basic module definition from the features section on this parcel.
-        let mut def = wagi_features(&invoice.bindle.id, &parcel);
+        let mut def = wagi_features(&invoice.bindle.id, &parcel, environment);
 
         // FIXME: This should get refactored out. Right now, every module needs its own
         // reference to a bindle server. This is because in the older modules.toml
@@ -465,7 +468,7 @@ fn top_modules(inv: &Invoice) -> Vec<Parcel> {
 }
 
 #[allow(clippy::map_clone)]
-fn wagi_features(inv_id: &Id, parcel: &Parcel) -> Module {
+fn wagi_features(inv_id: &Id, parcel: &Parcel, environment: &HashMap<String, String>) -> Module {
     let label = parcel.label.clone();
     let module = parcel_url(inv_id, label.sha256);
     let all_features = label.feature.unwrap_or_default();
@@ -490,7 +493,7 @@ fn wagi_features(inv_id: &Id, parcel: &Parcel) -> Module {
         route,
         allowed_hosts,
         volumes: None,
-        environment: None,
+        environment: Some(environment.clone()),
     }
 }
 


### PR DESCRIPTION
Previously if you were serving a bindle (`-b`) it dropped the env vars (`--env`).  This fixes that so bindled apps can use externally injected EVs.