### PR TITLE
improve support for environment variables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -634,9 +634,9 @@ dependencies = [
 
 [[package]]
 name = "env-file-reader"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f15ebd94eaa872d64d5ded8c5157bcde21dd19f2aa432be26f22b204fd1e809"
+checksum = "d00bb0c3f782b0967b28b4fd608ad3ce331817bdd120bbb193b3958a7a4a87b1"
 dependencies = [
  "regex",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -633,6 +633,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "env-file-reader"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f15ebd94eaa872d64d5ded8c5157bcde21dd19f2aa432be26f22b204fd1e809"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2665,6 +2674,7 @@ dependencies = [
  "bindle",
  "cap-std",
  "clap",
+ "env-file-reader",
  "futures",
  "hyper",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ tokio-rustls = "0.22"
 tracing-subscriber = "0.2"
 tracing = { version = "0.1", features = ["log"] }
 tracing-futures = "0.2"
-env-file-reader = "0.1"
+env-file-reader = "0.2"
 
 [dev-dependencies]
 bindle = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ tokio-rustls = "0.22"
 tracing-subscriber = "0.2"
 tracing = { version = "0.1", features = ["log"] }
 tracing-futures = "0.2"
+env-file-reader = "0.1"
 
 [dev-dependencies]
 bindle = "0.3"

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ _run:
 .PHONY: run-bindle
 run-bindle:
 	mkdir -p $(MODULE_CACHE)
-	RUST_LOG=$(LOG_LEVEL) cargo run --release -- -b $(BINDLE) --module-cache $(MODULE_CACHE) --bindle-url $(BINDLE_URL) --listen $(WAGI_IFACE) --default-host $(WAGI_HOST)
+	RUST_LOG=$(LOG_LEVEL) cargo run --release -- -b $(BINDLE) --module-cache $(MODULE_CACHE) --bindle-url $(BINDLE_URL) --listen $(WAGI_IFACE) --hostname $(WAGI_HOST)
 
 .PHONY: test
 test:

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -60,4 +60,4 @@ X_FULL_URL="http://localhost:3000/envwasm"
 X_RELATIVE_PATH=""    
 ```
 
-In addition, if a `[[module]]` section that matches the route also declares `environment` variables, those will be added.
+In addition, any values set at the command line with `--env` or `--env-file` will be loaded into all modules as well.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ pub struct Router {
     module_cache: PathBuf,
     default_host: String,
     use_tls: bool,
+    global_env_vars: HashMap<String, String>,
 }
 
 impl Router {
@@ -83,6 +84,7 @@ impl Router {
                             &self.base_log_dir,
                             self.default_host.to_owned(),
                             self.use_tls,
+                            self.global_env_vars.clone(),
                         )
                         .await;
                     Ok(res)
@@ -215,14 +217,12 @@ impl RouterBuilder {
         let invoice: Invoice = toml::from_slice(&data)?;
 
         let cache_dir = self.module_cache_dir.join("_ASSETS");
-        let mut mods = runtime::bindle::standalone_invoice_to_modules(
-            &invoice,
-            reader.parcel_dir,
-            cache_dir,
-            &self.global_env_vars,
-        )
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to turn Bindle into module configuration: {}", e))?;
+        let mut mods =
+            runtime::bindle::standalone_invoice_to_modules(&invoice, reader.parcel_dir, cache_dir)
+                .await
+                .map_err(|e| {
+                    anyhow::anyhow!("Failed to turn Bindle into module configuration: {}", e)
+                })?;
 
         mods.build_registry(
             &self.cache_config_path,
@@ -263,22 +263,6 @@ impl RouterBuilder {
     }
 
     fn build(self, mut config: ModuleConfig) -> Router {
-        // Apply the global variables on top of the user defined ones. This will overwrite existing
-        // user variables and add any ones that don't exist
-        if !self.global_env_vars.is_empty() {
-            config.modules = config
-                .modules
-                .into_iter()
-                .map(|mut module| {
-                    match module.environment.as_mut() {
-                        Some(current) => current.extend(self.global_env_vars.clone()),
-                        None => module.environment = Some(self.global_env_vars.clone()),
-                    }
-                    module
-                })
-                .collect();
-        }
-
         let module_store = ModuleStore::new(config);
         Router {
             module_store,
@@ -287,6 +271,7 @@ impl RouterBuilder {
             module_cache: self.module_cache_dir,
             default_host: self.default_host,
             use_tls: self.use_tls,
+            global_env_vars: self.global_env_vars,
         }
     }
 }
@@ -402,26 +387,9 @@ mod test {
         let cache = std::path::PathBuf::from("cache.toml");
         let mod_cache = tempfile::tempdir().expect("temp dir created");
 
-        let module = Module {
-            route: "/".to_string(),
-            module: "examples/hello.wat".to_owned(),
-            volumes: None,
-            environment: None,
-            entrypoint: None,
-            bindle_server: None,
-            allowed_hosts: None,
-        };
-
+        let module = Module::new("/".to_string(), "examples/hello.wat".to_owned());
         // We should be able to mount the same wasm at a separate route.
-        let module2 = Module {
-            route: "/foo".to_string(),
-            module: "examples/hello.wasm".to_owned(),
-            volumes: None,
-            environment: None,
-            entrypoint: None,
-            bindle_server: None,
-            allowed_hosts: None,
-        };
+        let module2 = Module::new("/foo".to_string(), "examples/hello.wasm".to_owned());
 
         let mut mc = ModuleConfig {
             modules: vec![module.clone(), module2.clone()].into_iter().collect(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,14 +243,11 @@ impl RouterBuilder {
     ) -> anyhow::Result<Router> {
         tracing::info!(name, "Loading bindle");
         let cache_dir = self.module_cache_dir.join("_ASSETS");
-        let mut mods = runtime::bindle::bindle_to_modules(
-            name,
-            bindle_server,
-            cache_dir,
-            &self.global_env_vars,
-        )
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to turn Bindle into module configuration: {}", e))?;
+        let mut mods = runtime::bindle::bindle_to_modules(name, bindle_server, cache_dir)
+            .await
+            .map_err(|e| {
+                anyhow::anyhow!("Failed to turn Bindle into module configuration: {}", e)
+            })?;
 
         mods.build_registry(
             &self.cache_config_path,
@@ -262,7 +259,7 @@ impl RouterBuilder {
         Ok(self.build(mods))
     }
 
-    fn build(self, mut config: ModuleConfig) -> Router {
+    fn build(self, config: ModuleConfig) -> Router {
         let module_store = ModuleStore::new(config);
         Router {
             module_store,

--- a/src/runtime/bindle.rs
+++ b/src/runtime/bindle.rs
@@ -250,7 +250,6 @@ pub(crate) async fn bindle_to_modules(
     name: &str,
     server_url: &str,
     asset_cache: PathBuf,
-    environment: &HashMap<String, String>,
 ) -> anyhow::Result<ModuleConfig> {
     let bindler = Client::new(server_url)?;
     let invoice = bindler.get_invoice(name).await?;

--- a/src/runtime/bindle.rs
+++ b/src/runtime/bindle.rs
@@ -255,7 +255,7 @@ pub(crate) async fn bindle_to_modules(
     let bindler = Client::new(server_url)?;
     let invoice = bindler.get_invoice(name).await?;
 
-    invoice_to_modules(&invoice, server_url, asset_cache, environment).await
+    invoice_to_modules(&invoice, server_url, asset_cache).await
 }
 
 /// Convenience function for generating an internal Parcel URL.
@@ -277,7 +277,6 @@ pub async fn standalone_invoice_to_modules(
     invoice: &Invoice,
     parcel_dir: PathBuf,
     asset_cache: PathBuf,
-    environment: &HashMap<String, String>,
 ) -> anyhow::Result<ModuleConfig> {
     let mut modules = IndexSet::new();
     let bindle_id = invoice.bindle.id.clone();
@@ -291,7 +290,7 @@ pub async fn standalone_invoice_to_modules(
 
     for parcel in top {
         // Create a basic module definition from the features section on this parcel.
-        let mut def = wagi_features(&invoice.bindle.id, &parcel, environment);
+        let mut def = wagi_features(&invoice.bindle.id, &parcel);
 
         def.module = parcel_dir
             .join(format!("{}.dat", parcel.label.sha256))
@@ -365,7 +364,6 @@ pub async fn invoice_to_modules(
     invoice: &Invoice,
     bindle_server: &str,
     asset_cache: PathBuf,
-    environment: &HashMap<String, String>,
 ) -> anyhow::Result<ModuleConfig> {
     let mut modules = IndexSet::new();
     let bindle_id = invoice.bindle.id.clone();
@@ -379,7 +377,7 @@ pub async fn invoice_to_modules(
 
     for parcel in top {
         // Create a basic module definition from the features section on this parcel.
-        let mut def = wagi_features(&invoice.bindle.id, &parcel, environment);
+        let mut def = wagi_features(&invoice.bindle.id, &parcel);
 
         // FIXME: This should get refactored out. Right now, every module needs its own
         // reference to a bindle server. This is because in the older modules.toml
@@ -468,7 +466,7 @@ fn top_modules(inv: &Invoice) -> Vec<Parcel> {
 }
 
 #[allow(clippy::map_clone)]
-fn wagi_features(inv_id: &Id, parcel: &Parcel, environment: &HashMap<String, String>) -> Module {
+fn wagi_features(inv_id: &Id, parcel: &Parcel) -> Module {
     let label = parcel.label.clone();
     let module = parcel_url(inv_id, label.sha256);
     let all_features = label.feature.unwrap_or_default();
@@ -493,7 +491,6 @@ fn wagi_features(inv_id: &Id, parcel: &Parcel, environment: &HashMap<String, Str
         route,
         allowed_hosts,
         volumes: None,
-        environment: Some(environment.clone()),
     }
 }
 

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1074,16 +1074,7 @@ mod test {
         let tf = write_temp_wat(ROUTES_WAT).expect("wrote tempfile");
         let testcases = possible_slashes_for_paths(tf.path().to_string_lossy().to_string());
         for test in testcases {
-            let module = Module {
-                route: "/base".to_string(),
-                module: test,
-                volumes: None,
-                environment: None,
-                entrypoint: None,
-                bindle_server: None,
-                allowed_hosts: None,
-            };
-
+            let module = Module::new("/base".to_string(), test);
             let ctx = WasiCtxBuilder::new().build();
             let engine = Engine::default();
             let store = Store::new(&engine, ctx);

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -91,8 +91,6 @@ pub struct Module {
     /// the location OUTSIDE the WASM. Two inside locations can map to the same outside
     /// location.
     pub volumes: Option<HashMap<String, String>>,
-    /// Set additional environment variables
-    pub environment: Option<HashMap<String, String>>,
     /// The name of the function that is the entrypoint for executing the module.
     /// The default is `_start`.
     pub entrypoint: Option<String>,
@@ -125,6 +123,17 @@ impl PartialEq for Module {
 impl Eq for Module {}
 
 impl Module {
+    pub fn new(route: String, module_uri: String) -> Self {
+        return Module {
+            route,
+            module: module_uri,
+            volumes: None,
+            entrypoint: None,
+            allowed_hosts: None,
+            bindle_server: None,
+        };
+    }
+
     /// Execute the WASM module in a WAGI
     ///
     /// The given `base_log_dir` should be a directory where all module logs will be stored. When
@@ -143,6 +152,7 @@ impl Module {
         base_log_dir: &Path,
         default_host: String,
         use_tls: bool,
+        env_vars: HashMap<String, String>,
     ) -> Response<Body> {
         // Read the parts in here
         let (parts, body) = req.into_parts();
@@ -167,6 +177,7 @@ impl Module {
                 &bld,
                 default_host.as_str(),
                 use_tls,
+                env_vars,
             )
         })
         .await
@@ -321,12 +332,13 @@ impl Module {
         client_addr: SocketAddr,
         default_host: &str,
         use_tls: bool,
+        environment: HashMap<String, String>,
     ) -> HashMap<String, String> {
         let (host, port) = self.parse_host_header_uri(&req.headers, &req.uri, default_host);
         // Note that we put these first so that there is no chance that they overwrite
         // the built-in vars. IMPORTANT: This is also why some values have empty strings
         // deliberately set (as opposed to omiting the pair altogether).
-        let mut headers = self.environment.clone().unwrap_or_default();
+        let mut headers = environment.clone();
 
         // CGI headers from RFC
         headers.insert("AUTH_TYPE".to_owned(), "".to_owned()); // Not currently supported
@@ -535,15 +547,12 @@ impl Module {
         base_log_dir: &Path,
         default_host: &str,
         use_tls: bool,
+        env: HashMap<String, String>,
     ) -> Result<Response<Body>, anyhow::Error> {
         let startup_span = tracing::info_span!("module instantiation").entered();
-
         let uri_path = req.uri.path();
-
-        let headers = self.build_headers(req, body.len(), client_addr, default_host, use_tls);
-
+        let headers = self.build_headers(req, body.len(), client_addr, default_host, use_tls, env);
         let stdin = ReadPipe::from(body);
-
         let stdout_buf: Vec<u8> = vec![];
         let stdout_mutex = Arc::new(RwLock::new(stdout_buf));
         let stdout = WritePipe::from_shared(stdout_mutex.clone());
@@ -964,26 +973,9 @@ mod test {
 
         let cache = PathBuf::from("cache.toml");
 
-        let module = Module {
-            route: "/base".to_string(),
-            module: urlish.clone(),
-            volumes: None,
-            environment: None,
-            entrypoint: None,
-            bindle_server: None,
-            allowed_hosts: None,
-        };
-
         // We should be able to mount the same wasm at a separate route.
-        let module2 = Module {
-            route: "/another/...".to_string(),
-            module: urlish,
-            volumes: None,
-            environment: None,
-            entrypoint: None,
-            bindle_server: None,
-            allowed_hosts: None,
-        };
+        let module = Module::new("/base".to_string(), urlish.clone());
+        let module2 = Module::new("/another/...".to_string(), urlish);
 
         let mut mc = ModuleConfig {
             modules: vec![module.clone(), module2.clone()].into_iter().collect(),
@@ -1038,15 +1030,7 @@ mod test {
     #[test]
     fn should_produce_relative_path() {
         let uri_path = "/static/images/icon.png";
-        let mut m = Module {
-            route: "/static/...".to_owned(),
-            module: "/tmp/fake".to_owned(),
-            volumes: None,
-            environment: None,
-            entrypoint: None,
-            bindle_server: None,
-            allowed_hosts: None,
-        };
+        let mut m = Module::new("/static/...".to_owned(), "/tmp/fake".to_owned());
         assert_eq!("images/icon.png", m.x_relative_path(uri_path));
 
         m.route = "/static/images/icon.png".to_owned();
@@ -1072,15 +1056,7 @@ mod test {
         let tf = write_temp_wat(ROUTES_WAT).expect("wrote tempfile");
         let urlish = format!("file:{}", tf.path().to_string_lossy());
 
-        let module = Module {
-            route: "/base".to_string(),
-            module: urlish,
-            volumes: None,
-            environment: None,
-            entrypoint: None,
-            bindle_server: None,
-            allowed_hosts: None,
-        };
+        let module = Module::new("/base".to_string(), urlish);
 
         let ctx = WasiCtxBuilder::new().build();
         let engine = Engine::default();
@@ -1226,15 +1202,7 @@ mod test {
 
     #[test]
     fn test_parse_host_header_uri() {
-        let module = Module {
-            route: "/base".to_string(),
-            module: "file:///no/such/path.wasm".to_owned(),
-            volumes: None,
-            environment: None,
-            entrypoint: None,
-            bindle_server: None,
-            allowed_hosts: None,
-        };
+        let module = Module::new("/base".to_string(), "file:///no/such/path.wasm".to_owned());
 
         let hmap = |val: &str| {
             let mut hm = hyper::HeaderMap::new();
@@ -1290,15 +1258,10 @@ mod test {
 
     #[test]
     fn test_headers() {
-        let module = Module {
-            route: "/path/...".to_string(),
-            module: "file:///no/such/path.wasm".to_owned(),
-            volumes: None,
-            environment: None,
-            entrypoint: None,
-            bindle_server: None,
-            allowed_hosts: None,
-        };
+        let module = Module::new(
+            "/path/...".to_string(),
+            "file:///no/such/path.wasm".to_owned(),
+        );
         let (req, _) = Request::builder()
             .uri("https://example.com:3000/path/test?foo=bar")
             .header("X-Test-Header", "hello")
@@ -1315,8 +1278,15 @@ mod test {
         let client_addr = "192.168.0.1:3000".parse().expect("Should parse IP");
         let default_host = "example.com:3000";
         let use_tls = true;
-        let headers =
-            module.build_headers(&req, content_length, client_addr, default_host, use_tls);
+        let env = std::collections::HashMap::with_capacity(0);
+        let headers = module.build_headers(
+            &req,
+            content_length,
+            client_addr,
+            default_host,
+            use_tls,
+            env,
+        );
 
         let want = |key: &str, expect: &str| {
             let v = headers

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -124,14 +124,14 @@ impl Eq for Module {}
 
 impl Module {
     pub fn new(route: String, module_uri: String) -> Self {
-        return Module {
+        Module {
             route,
             module: module_uri,
             volumes: None,
             entrypoint: None,
             allowed_hosts: None,
             bindle_server: None,
-        };
+        }
     }
 
     /// Execute the WASM module in a WAGI
@@ -338,7 +338,7 @@ impl Module {
         // Note that we put these first so that there is no chance that they overwrite
         // the built-in vars. IMPORTANT: This is also why some values have empty strings
         // deliberately set (as opposed to omiting the pair altogether).
-        let mut headers = environment.clone();
+        let mut headers = environment;
 
         // CGI headers from RFC
         headers.insert("AUTH_TYPE".to_owned(), "".to_owned()); // Not currently supported
@@ -929,7 +929,6 @@ mod test {
 
     use hyper::http::request::Request;
     use std::io::Write;
-    use std::net::SocketAddr;
     use std::path::PathBuf;
     use std::str::FromStr;
     use tempfile::NamedTempFile;


### PR DESCRIPTION
This adds support for reading environment variables from a file.

BREAKING CHANGE: In the course of working on this PR, I discovered that the internal situation for env vars was pretty sporadic. So I have fixed it so that env vars work the same regardless of source (Bindle, OCI, modules.toml, standalone Bindle).

As of now, the ONLY way to set environment variables is by using `--env` or `--env-file` at the CLI. `modules.toml` can no longer declare env vars, and the haphazard legacy support in Bindle has been removed as well (it never worked). I tested this against multiple scenarios to make sure that the same vars were being passed in the same way.

Closes #95 

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>