### PR TITLE
Revert PR 97 and add some inline docs

### DIFF
--- a/src/runtime/bindle.rs
+++ b/src/runtime/bindle.rs
@@ -402,7 +402,12 @@ pub async fn invoice_to_modules(
                         let purl = parcel_url(&bindle_id, member.label.sha256.clone());
                         trace!(parcel = %purl, "converting a parcel to an asset");
                         let puri = purl.parse().unwrap();
-                        cache_parcel_asset(
+
+                        // The returned cache path is the asset cache path PLUS the SHA256 of
+                        // the parcel that contains this asset. Essentially, we are mapping
+                        // the `/` path to `_ASSETS/$PARCEL_SHA` and then storing all the
+                        // files for that parcel in the same directory.
+                        let cache_path = cache_parcel_asset(
                             &bindler,
                             &puri,
                             asset_cache.clone(),
@@ -421,8 +426,7 @@ pub async fn invoice_to_modules(
                         // that to `/`
                         if def.volumes.is_none() {
                             let mut volumes = HashMap::new();
-                            volumes
-                                .insert("/".to_owned(), asset_cache.to_str().unwrap().to_owned());
+                            volumes.insert("/".to_owned(), cache_path.to_str().unwrap().to_owned());
                             def.volumes = Some(volumes);
                         }
                         trace!("Done with conversion");


### PR DESCRIPTION
PR #97 cleaned up a bug in the file cache. But I am not sure exactly what bug. However, when the path changed, it was mistakenly mounting the entire cache directory instead of just the parcel's cache.

So all I did was revert the patch with a note about how it is designed to work. I might be re-introducing whatever bug @simongdavies was fixing, but I am not entirely sure what bug that was. We might need one more followup PR.

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>