### PR TITLE
Fix script name, path info, and path translated

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2635,6 +2635,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "url-escape"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55c7bdc6152ebf118ddb53188af83c07b586778661434a21a3c475f06335771c"
+dependencies = [
+ "percent-encoding 2.1.0",
+]
+
+[[package]]
 name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2689,6 +2698,7 @@ dependencies = [
  "tracing-futures",
  "tracing-subscriber",
  "url 2.2.2",
+ "url-escape",
  "wasi-cap-std-sync",
  "wasi-common",
  "wasi-experimental-http-wasmtime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ tracing-subscriber = "0.2"
 tracing = { version = "0.1", features = ["log"] }
 tracing-futures = "0.2"
 env-file-reader = "0.2"
+url-escape = "0.1"
 
 [dev-dependencies]
 bindle = "0.3"

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -34,12 +34,15 @@ REMOTE_ADDR="127.0.0.1"
 # The server's IP address
 REMOTE_HOST="127.0.0.1"
 # The path info after the SCRIPT_NAME. If the route is /envwasm/... and the 
-# request is /envwasm/foo, the PathInfo is /foo
+# request is /envwasm/foo, the PathInfo is /foo. This value is run through a URL decoder
 PATH_INFO="/foo"
+# Wagi-specific: Same as PATH_INFO, but without being url-decoded. This can disambiguate
+# cases where things like '.', '+', and '/' appear in the path segment.
+X_RAW_PATH_INFO="/foo"
+# In Wagi, this is always the same as PATH_INFO.
+PATH_TRANSLATED="/foo"
 # The client-supplied query string, E.g. http://example.com?foo=bar becomes foo=bar
 QUERY_STRING=""
-# This is PATH_INFO after it has been run through a url-decode
-PATH_TRANSLATED="/foo"
 # The length of the body sent by the client. This is >0 only if the client sends a
 # non-empty body.
 CONTENT_LENGTH="0"

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -6,20 +6,21 @@ These are the environment variables set on every WAGI requests:
 
 ```bash
 # The name of the route that matched
-X_MATCHED_ROUTE="/envwasm"  # for example.com/envwasm
+X_MATCHED_ROUTE="/envwasm/..."  # for example.com/envwasm
 # The value of the HTTP Accept header from the client. This could be empty.
 HTTP_ACCEPT="*/*"
 # The HTTP method (GET/POST/PUT/etc) sent by the client
 REQUEST_METHOD="GET"
-# The protocol that the server is using. Normally this is "http" or "https"
-SERVER_PROTOCOL="http"
+# The protocol that the server is using. Usually it is HTTP/1.1
+SERVER_PROTOCOL="HTTP/1.1"
 # The value of the HTTP User-Agent header. This could be empty.
 HTTP_USER_AGENT="curl/7.64.1"
 # If the client sent a body (in a POST/PUT), the value of the client's
 # Content-Type header is here. This could be empty, even on a POST/PUT/PATCH.
 CONTENT_TYPE=""             # Usually set on POST/PUT
-# The name of the module requested. In a Bindle, this is the parcel name.
-SCRIPT_NAME="/path/to/env_wagi.wasm"
+# The URL path portion that goes to the top level of the script.
+# Note that the /... is not present here, though it is on X_MATCHED_ROUTE
+SCRIPT_NAME="/envwasm"
 # The name of the server software and it's MAJOR version.
 SERVER_SOFTWARE="WAGI/1"
 # The port upon which the server received its request
@@ -32,13 +33,13 @@ AUTH_TYPE=""
 REMOTE_ADDR="127.0.0.1"
 # The server's IP address
 REMOTE_HOST="127.0.0.1"
-# The path portion of the URL. E.g. http://example.com/envwasm becomes /envwasm
-PATH_INFO="/envwasm"
+# The path info after the SCRIPT_NAME. If the route is /envwasm/... and the 
+# request is /envwasm/foo, the PathInfo is /foo
+PATH_INFO="/foo"
 # The client-supplied query string, E.g. http://example.com?foo=bar becomes foo=bar
 QUERY_STRING=""
-# Currently, this is always the same as PATH_INFO, but is supplied for compatibility with
-# the CGI specification. It is not recommended that you use this variable.
-PATH_TRANSLATED="/envwasm"
+# This is PATH_INFO after it has been run through a url-decode
+PATH_TRANSLATED="/foo"
 # The length of the body sent by the client. This is >0 only if the client sends a
 # non-empty body.
 CONTENT_LENGTH="0"
@@ -54,10 +55,6 @@ REMOTE_USER=""
 # http://localhost:3000/foo/../envwasm, it will be normalized to
 # http://localhost:3000/envwasm.
 X_FULL_URL="http://localhost:3000/envwasm"
-# If a route containing /... matches, this is the part that matched "...".
-# For example, if the route is "/static/..." and the request comes for "/static/icon.png",
-# this will contain "icon.png"
-X_RELATIVE_PATH=""    
 ```
 
 In addition, any values set at the command line with `--env` or `--env-file` will be loaded into all modules as well.

--- a/docs/writing_modules.md
+++ b/docs/writing_modules.md
@@ -133,11 +133,11 @@ In general, you can use your language's built-in libraries to access this inform
 Consider the following HTTP request:
 
 ```console
-$ curl -vvv -H "HOST:foo.example.com" localhost:3000/env?greet=matt\&foo=bar
+$ curl -vvv -H "HOST:foo.example.com" localhost:3000/env/foo?greet=matt\&foo=bar
 *   Trying 127.0.0.1...
 * TCP_NODELAY set
 * Connected to localhost (127.0.0.1) port 3000 (#0)
-> GET /env?greet=matt&foo=bar HTTP/1.1
+> GET /env/foo?greet=matt&foo=bar HTTP/1.1
 > Host:foo.example.com
 > User-Agent: curl/7.64.1
 > Accept: */*
@@ -162,10 +162,8 @@ The above request will result in a whole bunch of environment variables being se
 
 ```
 REMOTE_ADDR = 127.0.0.1
-X_MATCHED_ROUTE = /env
 HTTP_HOST = foo.example.com
 SERVER_PORT = 80
-SCRIPT_NAME = /Users/technosophos/Code/Rust/env_wagi/target/wasm32-wasi/release/env_wagi.wasm
 CONTENT_LENGTH = 0
 CONTENT_TYPE =
 TEST_NAME = test value
@@ -175,15 +173,16 @@ GATEWAY_INTERFACE = CGI/1.1
 SERVER_NAME = foo.example.com
 HTTP_USER_AGENT = curl/7.64.1
 AUTH_TYPE =
-PATH_TRANSLATED = /env
-PATH_INFO = /env
+X_MATCHED_ROUTE = /env/...
+SCRIPT_NAME = /env
+PATH_INFO = /foo
+PATH_TRANSLATED = /foo
 HTTP_ACCEPT = */*
 SERVER_PROTOCOL = http
 REQUEST_METHOD = GET
 REMOTE_HOST = localhost
 X_FULL_URL = http://foo.example.com/env?greet=matt&foo=bar
 QUERY_STRING = greet=matt&foo=bar
-X_RELATIVE_PATH = ""
 ```
 
 See the [Environment Variables Reference](environment_variables.md) for a description of

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -395,7 +395,7 @@ impl Module {
         let script_name = self
             .route
             .strip_suffix("/...")
-            .map(|i| i.to_string())
+            .map(|i| format!("/{}", i)) // At the bare minimum, SCRIPT_NAME must be '/'
             .unwrap_or_else(|| self.route.clone());
         headers.insert("SCRIPT_NAME".to_owned(), script_name);
         // PATH_INFO is any path information after SCRIPT_NAME

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -374,22 +374,11 @@ impl Module {
         );
 
         headers.insert("GATEWAY_INTERFACE".to_owned(), WAGI_VERSION.to_owned());
-        headers.insert("X_MATCHED_ROUTE".to_owned(), self.route.to_owned()); // Specific to WAGI (not CGI)
-        headers.insert("PATH_INFO".to_owned(), req.uri.path().to_owned()); // TODO: Does this get trimmed?
 
-        // This also does not appear in the specification for CGI (largely because CGI did
-        // not necessarily "know about" URL rewrites). But it is very useful when combined
-        // with wildcard pattern matching.
-        headers.insert(
-            "X_RELATIVE_PATH".to_owned(),
-            self.x_relative_path(req.uri.path()),
-        );
+        // This is the Wagi route. This is different from PATH_INFO in that it may
+        // have a trailing '/..'
+        headers.insert("X_MATCHED_ROUTE".to_owned(), self.route.to_owned());
 
-        // NOTE: The security model of WAGI means that we do not give the actual
-        // translated path on the host filesystem, as that is off limits to the runtime.
-        // Right now, this just returns the same as PATH_INFO, but we could attempt to
-        // map it to something if we know what that "something" is.
-        headers.insert("PATH_TRANSLATED".to_owned(), req.uri.path().to_owned());
         headers.insert(
             "QUERY_STRING".to_owned(),
             req.uri.query().unwrap_or("").to_owned(),
@@ -400,24 +389,23 @@ impl Module {
         headers.insert("REMOTE_USER".to_owned(), "".to_owned()); // TODO: Parse this out of uri.authority?
         headers.insert("REQUEST_METHOD".to_owned(), req.method.to_string());
 
-        // Construct a safe path of the form / + FILE_NAME.
-        // This should not be a real path b/c that would disclose to the (untrusted)
-        // guest module some information about the underlying filesystem. We can
-        // assume, though, that the module author knows the name of the module.
-        // and currenlty Wagi does not attempt to obscure that.
-        //
-        // TODO: Is there any case where this comes in as `file:///` instead of `/some/path`?
-        let module_path = PathBuf::from(&self.module);
-        headers.insert(
-            "SCRIPT_NAME".to_owned(),
-            format!(
-                "/{}",
-                module_path
-                    .file_name()
-                    .unwrap_or_default()
-                    .to_string_lossy()
-            ),
-        );
+        // The Path component is /$SCRIPT_NAME/$PATH_INFO
+        // SCRIPT_NAME is the route that matched.
+        // https://datatracker.ietf.org/doc/html/rfc3875#section-4.1.13
+        let script_name = self
+            .route
+            .strip_suffix("/...")
+            .map(|i| i.to_string())
+            .unwrap_or_else(|| self.route.clone());
+        headers.insert("SCRIPT_NAME".to_owned(), script_name);
+        // PATH_INFO is any path information after SCRIPT_NAME
+        // https://datatracker.ietf.org/doc/html/rfc3875#section-4.1.5
+        let pathinfo = self.path_info(req.uri.path());
+        let path_translated = url_escape::decode(&pathinfo);
+        headers.insert("PATH_INFO".to_owned(), pathinfo.clone());
+        // PATH_TRANSLATED is the url-decoded version of PATH_INFO
+        // https://datatracker.ietf.org/doc/html/rfc3875#section-4.1.6
+        headers.insert("PATH_TRANSLATED".to_owned(), path_translated.to_string());
 
         // From the spec: "the server would use the contents of the request's Host header
         // field to select the correct virtual host."
@@ -512,7 +500,7 @@ impl Module {
     ///
     /// For example, if the match is `/foo/...` and the path is `/foo/bar`, it should return `"bar"`,
     /// but if the match is `/foo/bar` and the path is `/foo/bar`, it should return `""`.
-    fn x_relative_path(&self, uri_path: &str) -> String {
+    fn path_info(&self, uri_path: &str) -> String {
         uri_path
             .strip_prefix(
                 // Chop the `/...` off of the end if there is one.
@@ -520,8 +508,6 @@ impl Module {
                     .strip_suffix("/...")
                     .unwrap_or_else(|| self.route.as_str()),
             )
-            // Remove a leading `/` if there is one.
-            .map(|r| r.strip_prefix("/").unwrap_or(r))
             // It is possible that a root path request matching /... returns a None here,
             // so in that case the appropriate return is "".
             .unwrap_or("")
@@ -677,9 +663,21 @@ impl Module {
                         res.headers_mut().insert(CONTENT_TYPE, h.1.parse().unwrap());
                     }
                     "status" => {
-                        if let Ok(status) = h.1.parse::<hyper::StatusCode>() {
-                            tracing::info!(%status, "Setting status");
-                            *res.status_mut() = status;
+                        // The spec does not say that status is a sufficient response.
+                        // (It says that it may be added along with Content-Type, because
+                        // a status has a content type). However, CGI libraries in the wild
+                        // do not set content type correctly if a status is an error.
+                        // See https://datatracker.ietf.org/doc/html/rfc3875#section-6.2
+                        sufficient_response = true;
+                        // Status can be `Status CODE [STRING]`, and we just want the CODE.
+                        let status_code = h.1.split_once(' ').map(|(code, _)| code).unwrap_or(h.1);
+                        tracing::debug!(status_code, "Raw status code");
+                        match status_code.parse::<StatusCode>() {
+                            Ok(code) => *res.status_mut() = code,
+                            Err(e) => {
+                                tracing::log::warn!("Failed to parse code: {}", e);
+                                *res.status_mut() = StatusCode::BAD_GATEWAY;
+                            }
                         }
                     }
                     "location" => {
@@ -708,6 +706,8 @@ impl Module {
         // or a location header. Failure to return one of these is a 500 error.
         if !sufficient_response {
             return Ok(internal_error(
+                // Technically, we let `status` be sufficient, but this is more lenient
+                // than the specification.
                 "Exactly one of 'location' or 'content-type' must be specified",
             ));
         }
@@ -1037,16 +1037,18 @@ mod test {
     fn should_produce_relative_path() {
         let uri_path = "/static/images/icon.png";
         let mut m = Module::new("/static/...".to_owned(), "/tmp/fake".to_owned());
-        assert_eq!("images/icon.png", m.x_relative_path(uri_path));
+        assert_eq!("/images/icon.png", m.path_info(uri_path));
 
         m.route = "/static/images/icon.png".to_owned();
-        assert_eq!("", m.x_relative_path(uri_path));
+        assert_eq!("", m.path_info(uri_path));
 
+        // According to the spec, if "/" matches "/...", then a single "/" should be set
         m.route = "/...".to_owned();
-        assert_eq!("", m.x_relative_path("/"));
+        assert_eq!("/", m.path_info("/"));
 
+        // According to the spec, if "/" matches the SCRIPT_NAME, then "" should be set
         m.route = "/".to_owned();
-        assert_eq!("", m.x_relative_path("/"));
+        assert_eq!("", m.path_info("/"));
 
         // As a degenerate case, if the path does not match the prefix,
         // then it should return an empty path because this is not
@@ -1054,7 +1056,7 @@ mod test {
         // current Wagi, conceivably we could some day have to alter this
         // behavior. So this test is a canary for a breaking change.
         m.route = "/foo".to_owned();
-        assert_eq!("", m.x_relative_path("/bar"));
+        assert_eq!("", m.path_info("/bar"));
     }
 
     #[tokio::test]
@@ -1260,7 +1262,7 @@ mod test {
             "file:///no/such/path.wasm".to_owned(),
         );
         let (req, _) = Request::builder()
-            .uri("https://example.com:3000/path/test?foo=bar")
+            .uri("https://example.com:3000/path/test%3brun?foo=bar")
             .header("X-Test-Header", "hello")
             .header("Accept", "text/html")
             .header("User-agent", "test")
@@ -1290,7 +1292,7 @@ mod test {
                 .get(&key.to_owned())
                 .unwrap_or_else(|| panic!("expected to find key {}", key));
 
-            assert_eq!(expect, v)
+            assert_eq!(expect, v, "Key: {}", key)
         };
 
         // Content-type is set on output, so we don't test here.
@@ -1299,22 +1301,24 @@ mod test {
         want("REQUEST_METHOD", "POST");
         want("SERVER_PROTOCOL", "HTTP/1.1");
         want("HTTP_USER_AGENT", "test");
-        want("SCRIPT_NAME", "/path.wasm");
+        want("SCRIPT_NAME", "/path");
         want("SERVER_SOFTWARE", "WAGI/1");
         want("SERVER_PORT", "3000");
         want("SERVER_NAME", "example.com");
         want("AUTH_TYPE", "");
         want("REMOTE_ADDR", "192.168.0.1");
         want("REMOTE_ADDR", "192.168.0.1");
-        want("PATH_INFO", "/path/test");
+        want("PATH_INFO", "/test%3brun");
+        want("PATH_TRANSLATED", "/test;run");
         want("QUERY_STRING", "foo=bar");
-        want("PATH_TRANSLATED", "/path/test");
         want("CONTENT_LENGTH", "1234");
         want("HTTP_HOST", "example.com:3000");
         want("GATEWAY_INTERFACE", "CGI/1.1");
         want("REMOTE_USER", "");
-        want("X_FULL_URL", "https://example.com:3000/path/test?foo=bar");
-        want("X_RELATIVE_PATH", "test");
+        want(
+            "X_FULL_URL",
+            "https://example.com:3000/path/test%3brun?foo=bar",
+        );
 
         // Extra header should be passed through
         want("HTTP_X_TEST_HEADER", "hello");


### PR DESCRIPTION
This fixes several problems with CGI/1.1 compliance.

- SCRIPT_NAME is now correct
- PATH_INFO is now the pathy information after SCRIPT_NAME
- PATH_TRANSLATED is always PATH_INFO, because Wagi does not haven absolute file system path that differs from PATH_INFO
- SERVER_VERSION is also fixed

We had some difficulty interpreting parts of 4.1.6, ultimately deciding to ignore the prohibition in 4.1.5 on having path segments inside of the raw path info. (It just didn't make sense that a path could not contain a path segment because it required the end user to encode their path segments... which is silly)

Closes #101