### PR TITLE
feat: enable multi memory and module linking

### DIFF
--- a/src/wasm_runner.rs
+++ b/src/wasm_runner.rs
@@ -50,6 +50,11 @@ pub fn new_store_and_engine(
     ctx: WasiCtx,
 ) -> Result<(Store<WasiCtx>, Engine), anyhow::Error> {
     let mut config = Config::default();
+
+    // Enable multi memory and module linking support.
+    config.wasm_multi_memory(true);
+    config.wasm_module_linking(true);
+
     if let Ok(p) = std::fs::canonicalize(cache_config_path) {
         config.cache_config_load(p)?;
     };


### PR DESCRIPTION
This commit updates the default Wagi configuration to enable the multi
memory and module linking proposals in Wasmtime.
This allows for modules linked with Wasmlink to be executed directly by
Wagi.

This should not have any impact on existing modules that do not use the 
features.

Signed-off-by: Radu Matei <radu.matei@fermyon.com>