### PR TITLE
Rationalise Wasm module source options

### DIFF
--- a/docs/configuring_and_running.md
+++ b/docs/configuring_and_running.md
@@ -12,9 +12,11 @@ The `wagi` server is run from the command line. It has a few flags:
 - `-c`|`--config`: The path to a `modules.toml` configuration
 - `-b`|`--bindle`: The name of a bindle to use for configuration, e.g. `-b example.com/hello/1.0.0`.
   - You *must* specify _one of_ `--config` or `--bindle`.
-  - If you specify both, it will use the `--bindle`
+  - It's an error to specify both.
 - `--bindle-path`: A base path for standalone bindles
-- `--bindle-url`: The full URL to a Bindle server. Default is `http://localhost:8080/v1`
+- `--bindle-url`: The full URL to a Bindle server.
+  - If you specified `--bindle` you *must* specify _one of_ `--bindle-path` or `--bindle-url`.
+  - It's an error to specify both.
 - `--cache`: The path to an optional `cache.toml` configuration file (see the caching section below)
 - `--default-host`: The hostname (with port) to use when no HOST header is provided. Default is `localhost:3000`
 - `-l`|`--listen`: The IP address and port to listen on. Default is `127.0.0.1:3000`


### PR DESCRIPTION
This is a breaking change to the CLI.  Under the new rules:

* You must provide _exactly one_ of a module config file and a bindle ID.
* If you provide a bindle ID, you must provide _exactly one_ of a standalone directory or server URL.
* The module file and Bindle server URL are _no longer_ defaulted.
* It is _no longer_ an error to have the `BINDLE_URL` EV defined when you are using a module config file.  (It _is_ an error to pass `--bindle-path` because that can only happen via an explicit action; because of Clap limitations, though, it is not an error to pass `--bindle-url` on the CLI.)

The resulting behaviour is:

```
# Didn't pass anything - NOW AN ERROR, no longer defaults to ./modules.toml
13:01 $ ./target/debug/wagi 
error: The following required arguments were not provided:
    <--config <MODULES_TOML>|--bindle <BINDLE_ID>>

USAGE:
    wagi [OPTIONS] <--config <MODULES_TOML>|--bindle <BINDLE_ID>>

# --------------------------------------------------------------------------------

# Passed module file only - HAPPY PATH
13:01 $ ./target/debug/wagi -c foo.toml

# --------------------------------------------------------------------------------

# Passed a module file and bindle ID - STILL AN ERROR, new message
13:01 $ ./target/debug/wagi -b foo/1.2.3 -c foo.toml
error: The argument '--config <MODULES_TOML>' cannot be used with one or more of the other specified arguments

USAGE:
    wagi <--bindle-path <bindle_path>|--bindle-url <BINDLE_URL>> <--config <MODULES_TOML>|--bindle <BINDLE_ID>>

# --------------------------------------------------------------------------------

# Passed both a module file and bindle directory - STILL AN ERROR though the message is a bit misleading
13:04 $ ./target/debug/wagi -c foo.toml --bindle-path foo
error: The following required arguments were not provided:
    --bindle <BINDLE_ID>
    <--bindle-path <bindle_path>|--bindle-url <BINDLE_URL>>

USAGE:
    wagi <--bindle-path <bindle_path>|--bindle-url <BINDLE_URL>> <--config <MODULES_TOML>|--bindle <BINDLE_ID>>

# --------------------------------------------------------------------------------

# Passed both a module file and bindle URL - NOW ALLOWED
13:05 $ ./target/debug/wagi -c foo.toml --bindle-url foo

# --------------------------------------------------------------------------------

# Passed only a bindle ID - NOW AN ERROR, no longer defaults server URL
13:01 $ ./target/debug/wagi -b foo/1.2.3
error: The following required arguments were not provided:
    <--bindle-path <bindle_path>|--bindle-url <BINDLE_URL>>

USAGE:
    wagi <--bindle-path <bindle_path>|--bindle-url <BINDLE_URL>> <--config <MODULES_TOML>|--bindle <BINDLE_ID>>

# --------------------------------------------------------------------------------

# Passed bindle ID and standalone directory - HAPPY PATH
13:02 $ ./target/debug/wagi -b foo/1.2.3 --bindle-path foo

# --------------------------------------------------------------------------------

# Passed bindle ID and server URL - HAPPY PATH
13:04 $ ./target/debug/wagi -b foo/1.2.3 --bindle-url foo

# --------------------------------------------------------------------------------

# Passed bindle ID and standalone directory *and* server URL - STILL AN ERROR, new message
13:04 $ ./target/debug/wagi -b foo/1.2.3 --bindle-path foo --bindle-url foo
error: The argument '--bindle-path <bindle_path>' cannot be used with one or more of the other specified arguments

USAGE:
    wagi <--bindle-path <bindle_path>|--bindle-url <BINDLE_URL>> <--config <MODULES_TOML>|--bindle <BINDLE_ID>>
```
