### PR TITLE
ci(release.yaml): add cross-compiled aarch64 config

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,9 +13,42 @@ jobs:
     strategy:
       matrix:
         config:
-          - { os: "ubuntu-latest", arch: "amd64", extension: "", env: {} }
-          - { os: "macos-latest", arch: "amd64", extension: "", env: {} }
-          - { os: "windows-latest", arch: "amd64", extension: ".exe", env: {} }
+          - {
+              os: "ubuntu-latest",
+              arch: "amd64",
+              extension: "",
+              args: "--all-features --release",
+              target: "",
+              targetDir: "target/release",
+              env: {},
+            }
+          - {
+              os: "ubuntu-latest",
+              arch: "aarch64",
+              extension: "",
+              args: "--all-features --release --target aarch64-unknown-linux-gnu",
+              target: "aarch64-unknown-linux-gnu",
+              targetDir: "target/aarch64-unknown-linux-gnu/release",
+              env: { OPENSSL_DIR: "/usr/local/openssl-aarch64" },
+            }
+          - {
+              os: "macos-latest",
+              arch: "amd64",
+              extension: "",
+              args: "--all-features --release",
+              target: "",
+              targetDir: "target/release",
+              env: {},
+            }
+          - {
+              os: "windows-latest",
+              arch: "amd64",
+              extension: ".exe",
+              args: "--all-features --release",
+              target: "",
+              targetDir: "target/release",
+              env: {},
+            }
     steps:
       - uses: actions/checkout@v2
 
@@ -35,6 +68,23 @@ jobs:
           OS=$(echo "${{ runner.os }}" | tr '[:upper:]' '[:lower:]')
           echo "RUNNER_OS=$OS" >> $GITHUB_ENV
 
+      - name: setup for cross-compiled aarch64 build
+        if: matrix.config.arch == 'aarch64'
+        run: |
+          sudo apt update
+          sudo apt install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+          cd /tmp
+          git clone https://github.com/openssl/openssl
+          cd openssl
+          git checkout OpenSSL_1_1_1l
+          sudo mkdir -p $OPENSSL_DIR
+          ./Configure linux-aarch64 --prefix=$OPENSSL_DIR --openssldir=$OPENSSL_DIR shared
+          make CC=aarch64-linux-gnu-gcc
+          sudo make install
+          rustup target add aarch64-unknown-linux-gnu
+          echo '[target.aarch64-unknown-linux-gnu]' >> ${HOME}/.cargo/config.toml
+          echo 'linker = "aarch64-linux-gnu-gcc"' >> ${HOME}/.cargo/config.toml
+
       # hack: install rustfmt to work around darwin toolchain issues
       - name: "(macOS) install dev tools"
         if: runner.os == 'macOS'
@@ -47,13 +97,13 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: "--all-features --release"
+          args: ${{ matrix.config.args }}
 
       - name: package release assets
         shell: bash
         run: |
           mkdir _dist
-          cp README.md LICENSE.txt target/release/wagi${{ matrix.config.extension }} _dist/
+          cp README.md LICENSE.txt ${{ matrix.config.targetDir }}/wagi${{ matrix.config.extension }} _dist/
           cd _dist
           tar czf wagi-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz README.md LICENSE.txt wagi${{ matrix.config.extension }}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,6 @@ jobs:
               arch: "amd64",
               extension: "",
               args: "--all-features --release",
-              target: "",
               targetDir: "target/release",
               env: {},
             }
@@ -27,7 +26,6 @@ jobs:
               arch: "aarch64",
               extension: "",
               args: "--all-features --release --target aarch64-unknown-linux-gnu",
-              target: "aarch64-unknown-linux-gnu",
               targetDir: "target/aarch64-unknown-linux-gnu/release",
               env: { OPENSSL_DIR: "/usr/local/openssl-aarch64" },
             }
@@ -36,7 +34,6 @@ jobs:
               arch: "amd64",
               extension: "",
               args: "--all-features --release",
-              target: "",
               targetDir: "target/release",
               env: {},
             }
@@ -45,7 +42,6 @@ jobs:
               arch: "amd64",
               extension: ".exe",
               args: "--all-features --release",
-              target: "",
               targetDir: "target/release",
               env: {},
             }


### PR DESCRIPTION
* Adds a cross-compiled linux aarch64 entry (and add'l logic) into the GH release workflow

Approach derived from [the Krustlet project](https://github.com/krustlet/krustlet/blob/a303840c1fd86f2e07f687be47a137be2ecfd326/.github/workflows/release.yml).

Ref https://github.com/deislabs/wagi/issues/141

Question: Do we want to update the `rust.yaml` action to add build/compile of this target as well?  Changes would be more impactful to that file, so I wanted to ask first.

Tested release job on fork via https://github.com/vdice/wagi/actions/runs/1752378468 and resulting aarch64 binary on arm64 linux VM:
```
ubuntu@ip-172-31-95-42:~$ uname -a
Linux ip-172-31-95-42 #30~20.04.1-Ubuntu SMP Thu Jan 13 11:49:06 UTC 2022 aarch64 aarch64 aarch64 GNU/Linux
ubuntu@ip-172-31-95-42:~$ ./wagi --version
WAGI Server 0.4.0
```