### PR TITLE
chore(*): bump version to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2709,7 +2709,7 @@ checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "wagi"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
     name    = "wagi"
-    version = "0.4.0"
+    version = "0.5.0"
     authors = ["Matt Butcher <matt.butcher@microsoft.com>"]
     edition = "2021"
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -8,8 +8,8 @@ and download the desired release. Usually, the most recent release is the one yo
 You can generate and compare the SHA with `shasum`:
 
 ```console
-$ shasum wagi-v0.4.0-linux-amd64.tar.gz
-ad4114b2ed9e510a8c24348d5ea544da55c685f5  wagi-v0.3.0-linux-amd64.tar.gz
+$ shasum wagi-v0.5.0-linux-amd64.tar.gz
+ad4114b2ed9e510a8c24348d5ea544da55c685f5  wagi-v0.5.0-linux-amd64.tar.gz
 ```
 
 You can then compare that SHA with the one present in the release notes.
@@ -40,7 +40,7 @@ To build a static binary, run the following command:
 
 ```console
 $ make build
-   Compiling wagi v0.4.0 (/Users/technosophos/Code/Rust/wagi)
+   Compiling wagi v0.5.0 (/Users/technosophos/Code/Rust/wagi)
     Finished release [optimized] target(s) in 18.47s
 ```
 


### PR DESCRIPTION
* Bumps version to 0.5.0 in anticipation of the next release

It's been a while since the last one and we have some new fixes/features, plus the addition of a cross-compiled aarch64 binary in the release pipeline.  That being said, there are a few outstanding PRs -- not sure if we wanted to hold up for either: https://github.com/deislabs/wagi/pulls

Here's the changelog as of writing:

- chore(*): bump version to 0.5.0 caf7b46ac3e7c473f8a1aa427dea92425da24ce7 (Vaughn Dice)
- remove unused target field in matrix 4fb7dfde9d01fd8f55903a621e8dfced75daa968 (Vaughn Dice)
- ci(release.yaml): add cross-compiled aarch64 config 0b1dc24a022028189c2938625326821a77eccf4f (Vaughn Dice)
- upgrade wasmtime 0.33 and experimental HTTP 0.8 271fc455e8753672957f7c6c595750f28b010cc0 (Matt Butcher)
- Include source code for HTTP example (#145) 7c0f6d3e4f99761445eea8e23948ee5a7a335ab5 (itowlson)
- Docs for new flag behaviour 8d7d511cdc955bd8f5268792dcd3dd6b55f6b404 (itowlson)
- Rationalise Wasm module source options cc7005ac0f659f32cd804138942cd94f4e623589 (itowlson)
- Centralise Wasm linking and instantiation (#143) c51263b42515560e868cccdf2352caf147ffd6e0 (itowlson)
- Fix dispatcher not linking the HTTP library (#142) f941887757584e6134a2ead3c8b4ac299e005957 (Radu Matei)
- Change use Bindle ID in help text 8cd7a59006ea99b0b139309de8e5d470517c9341 (Adam Reese)
- Fix spurious log on no assets (#133) d69ffd3762ed8bcacb76f5afd0698803e5f1fe9d (itowlson)
- feat: enable multi memory and module linking 045194ae8b72277db4bdd3af7c120a28e7458d02 (Radu Matei)
- fix(docs): fix spelling bath -> path ... bath is better tho a987858b7979189aa5849ad25f536edcd2782593 (Michelle Noorali)
- chore: update wasi-experimental-http-wasmtime c33accdc38ac99b41bd9520b5794ef28196d0a54 (Radu Matei)
- fix(docs): fix typo Fo -> For ec14e4567e12e639eaab9728652ed29f643937c3 (Michelle Noorali)
- Update Wasmtime to v0.31 fb9d1606940c62fd5435288caae3ae18e84670ca (Radu Matei)
- Fixed failed match when parent and dynamic both had slashes. Fixed /foo/... matching /foobar (blush) (#129) 3486d995e41979dbf7193d6e252d278f243ae991 (itowlson)
- Placate Clippy (#126) abecd21f5da10dbf03b5e5d7fbac9f974af9bc61 (itowlson)
- Major refactoring (#125) c48bdd6a205920cf90878c558b60fc667289431a (itowlson)