### PR TITLE
This caches the modules once, and then uses the cached version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2723,6 +2723,7 @@ dependencies = [
  "futures",
  "hyper",
  "indexmap",
+ "lazy_static",
  "oci-distribution",
  "serde",
  "sha2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@
     futures                         = "0.3"
     hyper                           = { version = "0.14", features = ["full"] }
     indexmap                        = { version = "^1.6.2", features = ["serde"] }
+    lazy_static                     = "1.4.0"
     oci-distribution                = "0.6"
     serde                           = { version = "1.0", features = ["derive"] }
     sha2                            = "0.9"

--- a/src/wasm_module.rs
+++ b/src/wasm_module.rs
@@ -4,6 +4,9 @@ use wasi_common::pipe::{ReadPipe, WritePipe};
 use wasmtime::*;
 use wasmtime_wasi::*;
 
+use std::collections::HashMap;
+use lazy_static::lazy_static;
+
 // In future this might be pre-instantiated or something like that, so we will
 // just abstract it to be safe.
 #[derive(Clone)]
@@ -11,10 +14,35 @@ pub enum WasmModuleSource {
     Blob(Arc<Vec<u8>>),
 }
 
+lazy_static! {
+    /// A cache of the modules.
+    static ref CACHE: RwLock<HashMap<Vec<u8>, Module>> = RwLock::new(HashMap::new());
+}
+
 impl WasmModuleSource {
-    pub fn load_module(&self, store: &Store<WasiCtx>) -> anyhow::Result<wasmtime::Module> {
+    pub fn load_module(&self, engine: &Engine) -> anyhow::Result<wasmtime::Module> {
         match self {
-            Self::Blob(bytes) => wasmtime::Module::new(store.engine(), &**bytes),
+            Self::Blob(bytes) => {
+                // If we already have the module, return a clone of the cached version.
+                // Otherwise we will load the module from bytes, cache the result, and
+                // then return the module.
+                let data = &**bytes;
+                let (wasm_mod, cache_hit) = match CACHE.read().unwrap().get(data) {
+                    None => {
+                        tracing::debug!("Cache miss. Instantiating new copy");
+                        (wasmtime::Module::new(engine, &**bytes)?, false)
+                    },
+                    Some(m) => {
+                        tracing::debug!("Cache hit");
+                        (m.clone(), true)
+                    },
+                };
+
+                if !cache_hit {
+                    CACHE.write().unwrap().insert(data.to_vec(), wasm_mod.clone());
+                }
+                Ok(wasm_mod)
+            },
         }
     }
 }


### PR DESCRIPTION
This changes the way Wagi caches modules.

In this version, Wagi compiles the modules once and then caches them in memory. Each subsequent request for that module uses the cached module instead of regenerating the module.

In testing, this dropped the average page load time of Bartholomew from 560ms to 36ms. Tested with siege, too, and saw similar performance gains across both Bartholomew and Fileserver.gr

Note that what we give up here is file-based caching. So if we want to keep that, we might need to rework this a bit.

Signed-off-by: Matt Butcher <matt.butcher@fermyon.com>