### PR TITLE
Load modules at startup, and clone per request

### DIFF
--- a/src/wasm_module.rs
+++ b/src/wasm_module.rs
@@ -2,27 +2,18 @@ use std::{fmt::Debug, sync::{Arc, RwLock}};
 
 use wasi_common::pipe::{ReadPipe, WritePipe};
 use wasmtime::*;
-use wasmtime_wasi::*;
 
 // In future this might be pre-instantiated or something like that, so we will
 // just abstract it to be safe.
 #[derive(Clone)]
-pub enum WasmModuleSource {
-    Blob(Arc<Vec<u8>>),
+pub enum CompiledWasmModule {
+    Object(Module, Engine)
 }
 
-impl WasmModuleSource {
-    pub fn load_module(&self, store: &Store<WasiCtx>) -> anyhow::Result<wasmtime::Module> {
-        match self {
-            Self::Blob(bytes) => wasmtime::Module::new(store.engine(), &**bytes),
-        }
-    }
-}
-
-impl Debug for WasmModuleSource {
+impl Debug for CompiledWasmModule {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Blob(v) => f.write_fmt(format_args!("Blob(length={})", v.len())),
+            Self::Object(m, _) => f.write_fmt(format_args!("Object(Module={:?})", m.name())),
         }
     }
 }


### PR DESCRIPTION
This preloads all modules right when Wagi starts up. And then for each request, it clones and executes the module. According to Wasmtime docs, this is a fully supported workflow. I managed to shave off quite a bit more time here than what I got in #151.


```
Lifting the server siege...
Transactions:                   2433 hits
Availability:                 100.00 %
Elapsed time:                   5.23 secs
Data transferred:              72.78 MB
Response time:                  0.05 secs
Transaction rate:             465.20 trans/sec
Throughput:                    13.92 MB/sec
Concurrency:                   24.86
Successful transactions:        2433
Failed transactions:               0
Longest transaction:            0.13
Shortest transaction:           0.01
```

Supersedes #151 

Signed-off-by: Matt Butcher <matt.butcher@fermyon.com>