### PR TITLE
Release 0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3155,7 +3155,7 @@ checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "wagi"
-version = "0.5.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
     name    = "wagi"
-    version = "0.5.0"
+    version = "0.6.1"
     authors = ["Matt Butcher <matt.butcher@microsoft.com>"]
     edition = "2021"
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -8,8 +8,8 @@ and download the desired release. Usually, the most recent release is the one yo
 You can generate and compare the SHA with `shasum`:
 
 ```console
-$ shasum wagi-v0.5.0-linux-amd64.tar.gz
-ad4114b2ed9e510a8c24348d5ea544da55c685f5  wagi-v0.5.0-linux-amd64.tar.gz
+$ shasum wagi-v0.6.1-linux-amd64.tar.gz
+ad4114b2ed9e510a8c24348d5ea544da55c685f5  wagi-v0.6.1-linux-amd64.tar.gz
 ```
 
 You can then compare that SHA with the one present in the release notes.
@@ -40,7 +40,7 @@ To build a static binary, run the following command:
 
 ```console
 $ make build
-   Compiling wagi v0.5.0 (/Users/technosophos/Code/Rust/wagi)
+   Compiling wagi v0.6.1 (/Users/technosophos/Code/Rust/wagi)
     Finished release [optimized] target(s) in 18.47s
 ```
 


### PR DESCRIPTION
Fixes my mistaken release of 0.6.0.

Signed-off-by: Matt Butcher <matt.butcher@fermyon.com>