### PR TITLE
feat(*): add support for http basic auth to bindle server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3172,6 +3172,7 @@ dependencies = [
  "hyper",
  "indexmap",
  "oci-distribution",
+ "reqwest",
  "serde",
  "sha2 0.9.5",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@
     hyper                           = { version = "0.14", features = ["full"] }
     indexmap                        = { version = "^1.6.2", features = ["serde"] }
     oci-distribution                = "0.6"
+    reqwest                         = { version = "0.11", features = ["stream"] }
     serde                           = { version = "1.0", features = ["derive"] }
     sha2                            = "0.9"
     tokio                           = { version = "1.1", features = ["full"] }

--- a/src/bindle_util.rs
+++ b/src/bindle_util.rs
@@ -211,6 +211,67 @@ fn parse_csv(text: &str) -> Vec<String> {
     text.split(',').map(|v| v.to_owned()).collect()  // TODO: trim etc.?
 }
 
+// Bindle client/auth utils, derived from github.com/deislabs/hippo-cli
+
+use std::sync::Arc;
+
+use bindle::client::{
+    tokens::{HttpBasic, NoToken, TokenManager},
+    Client, ClientBuilder,
+};
+
+#[derive(Clone)]
+pub struct BindleConnectionInfo {
+    base_url: String,
+    allow_insecure: bool,
+    token_manager: AnyAuth,
+}
+
+impl BindleConnectionInfo {
+    pub fn new<I: Into<String>>(
+        base_url: I,
+        allow_insecure: bool,
+        username: Option<String>,
+        password: Option<String>,
+    ) -> Self {
+        let token_manager: Box<dyn TokenManager + Send + Sync> = match (username, password) {
+            (Some(u), Some(p)) => Box::new(HttpBasic::new(&u, &p)),
+            _ => Box::new(NoToken::default()),
+        };
+
+        Self {
+            base_url: base_url.into(),
+            allow_insecure,
+            token_manager: AnyAuth {
+                token_manager: Arc::new(token_manager),
+            },
+        }
+    }
+
+    pub fn client(&self) -> bindle::client::Result<Client<AnyAuth>> {
+        let builder = ClientBuilder::default()
+            .http2_prior_knowledge(false)
+            .danger_accept_invalid_certs(self.allow_insecure);
+        builder.build(&self.base_url, self.token_manager.clone())
+    }
+}
+
+#[derive(Clone)]
+pub struct AnyAuth {
+    token_manager: Arc<Box<dyn TokenManager + Send + Sync>>,
+}
+
+#[async_trait::async_trait]
+impl TokenManager for AnyAuth {
+    async fn apply_auth_header(
+        &self,
+        builder: reqwest::RequestBuilder,
+    ) -> bindle::client::Result<reqwest::RequestBuilder> {
+        self.token_manager.apply_auth_header(builder).await
+    }
+}
+
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/handler_loader/emplacer.rs
+++ b/src/handler_loader/emplacer.rs
@@ -61,8 +61,8 @@ impl Emplacer {
                 Ok(EmplacedHandlerConfiguration::ModuleMapFile(path.clone())),
             HandlerConfigurationSource::StandaloneBindle(bindle_base_dir, id) =>
                 self.emplace_standalone_bindle(&bindle_base_dir, &id).await,
-            HandlerConfigurationSource::RemoteBindle(id, bindle_connection_info) =>
-                self.emplace_remote_bindle(&id, bindle_connection_info).await,
+            HandlerConfigurationSource::RemoteBindle(bindle_connection_info, id) =>
+                self.emplace_remote_bindle(bindle_connection_info, &id).await,
         }.with_context(|| "Error caching assets from bindle")
     }
 
@@ -90,7 +90,7 @@ impl Emplacer {
         self.emplace_bindle(&reader, id).await
     }
 
-    async fn emplace_remote_bindle(self, id: &bindle::Id, bindle_connection_info: crate::bindle_util::BindleConnectionInfo) -> anyhow::Result<EmplacedHandlerConfiguration> {
+    async fn emplace_remote_bindle(self, bindle_connection_info: crate::bindle_util::BindleConnectionInfo, id: &bindle::Id) -> anyhow::Result<EmplacedHandlerConfiguration> {
         self.emplace_bindle(&bindle_connection_info.client()?, id).await
     }
 

--- a/src/wagi_app.rs
+++ b/src/wagi_app.rs
@@ -337,8 +337,8 @@ fn parse_handler_configuration_source(
         (Some(bindle_id), None, Some(bindle_url), None) => {
             match url::Url::parse(bindle_url) {
                 Ok(url) => Ok(HandlerConfigurationSource::RemoteBindle(
-                    bindle::Id::try_from(bindle_id)?,
                     parse_bindle_connection_info(url, &matches)?,
+                    bindle::Id::try_from(bindle_id)?,
                 )),
                 Err(e) => Err(anyhow::anyhow!("Invalid Bindle server URL: {}", e)),
             }

--- a/src/wagi_config.rs
+++ b/src/wagi_config.rs
@@ -6,6 +6,9 @@ use crate::{
     request::RequestGlobalContext,
 };
 
+// TODO: figure out how to re-apply the Debug trait here (and on HandlerConfigurationSource)
+// At time of writing, it was removed on account of the bindle::client::tokens::token_manager
+// not implementing this trait (see crate::bindle_util::BindleConnectionInfo)
 #[derive(Clone)]
 pub struct WagiConfiguration {
     pub handlers: HandlerConfigurationSource,
@@ -20,7 +23,7 @@ pub struct WagiConfiguration {
 pub enum HandlerConfigurationSource {
     ModuleConfigFile(PathBuf),
     StandaloneBindle(PathBuf, bindle::Id),
-    RemoteBindle(bindle::Id, BindleConnectionInfo),
+    RemoteBindle(BindleConnectionInfo, bindle::Id),
 }
 
 #[derive(Clone, Debug)]

--- a/src/wagi_config.rs
+++ b/src/wagi_config.rs
@@ -16,7 +16,19 @@ pub struct WagiConfiguration {
 pub enum HandlerConfigurationSource {
     ModuleConfigFile(PathBuf),
     StandaloneBindle(PathBuf, bindle::Id),
-    RemoteBindle(url::Url, bindle::Id),
+    RemoteBindle(url::Url, bindle::Id, BindleAuthentication),
+}
+
+#[derive(Clone, Debug)]
+pub enum BindleAuthenticationStrategy {
+    NoAuth,
+    BasicHTTPAuth(String, String)
+}
+
+#[derive(Clone, Debug)]
+pub struct BindleAuthentication {
+    pub kind: BindleAuthenticationStrategy,
+    pub insecure: bool
 }
 
 #[derive(Clone, Debug)]

--- a/src/wagi_config.rs
+++ b/src/wagi_config.rs
@@ -1,8 +1,12 @@
 use std::{collections::HashMap, net::SocketAddr, path::PathBuf};
 
-use crate::{handler_loader::WasmCompilationSettings, request::RequestGlobalContext};
+use crate::{
+    bindle_util::BindleConnectionInfo,
+    handler_loader::WasmCompilationSettings,
+    request::RequestGlobalContext,
+};
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct WagiConfiguration {
     pub handlers: HandlerConfigurationSource,
     pub env_vars: HashMap<String, String>,
@@ -12,23 +16,11 @@ pub struct WagiConfiguration {
     pub log_dir: PathBuf,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub enum HandlerConfigurationSource {
     ModuleConfigFile(PathBuf),
     StandaloneBindle(PathBuf, bindle::Id),
-    RemoteBindle(url::Url, bindle::Id, BindleAuthentication),
-}
-
-#[derive(Clone, Debug)]
-pub enum BindleAuthenticationStrategy {
-    NoAuth,
-    BasicHTTPAuth(String, String)
-}
-
-#[derive(Clone, Debug)]
-pub struct BindleAuthentication {
-    pub kind: BindleAuthenticationStrategy,
-    pub insecure: bool
+    RemoteBindle(bindle::Id, BindleConnectionInfo),
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
* adds support for sending in http basic auth creds for comms with the bindle server  
* also adds support for ignoring bindle server cert errors

Closes https://github.com/deislabs/wagi/issues/154