### PR TITLE
add 'argv' argument to modules.toml and bindle

### DIFF
--- a/docs/configuring_and_running.md
+++ b/docs/configuring_and_running.md
@@ -57,7 +57,8 @@ In a nutshell, these are the fields that `modules.toml` supports.
   - `route` (REQUIRED): The path that is appended to the server URL to create a full URL (e.g. `/foo` becomes `https://example.com/foo`)
   - `module` (REQUIRED): A module reference. See Module References below.
   - `repository`: RESERVED for future use
-  - `entrypoint` (default: `_start`): The name of the function within the module. This will directly execute that function. Most WASM/WASI implementations create a `_start` function by default. An example of a module that declares 3 entrypoints can be found [here](https://github.com/technosophos/hello-wagi).
+  - `entrypoint` (Optional, default: `_start`): The name of the function within the module. This will directly execute that function. Most WASM/WASI implementations create a `_start` function by default. An example of a module that declares 3 entrypoints can be found [here](https://github.com/technosophos/hello-wagi).
+  - `argv`: (Optional, default: "${SCRIPT_NAME} ${ARGS}"). This determines what the `argv` array looks like for the invoked program. The CGI 1.1 spec says that the `argv` array should contain the script name followed by the parameters. However, some Wasm modules require specifically formatted `argv`. This allows a way to override the CGI 1.1 defaults. Example: `argv = "ruby index.rb ${SCRIPT_NAME} ${ARGS}"`. This could expand to `ruby index.rb /example param1=val1 param2=val2`
   
 Here is a brief example of a `modules.toml` file that declares two routes:
 
@@ -262,6 +263,7 @@ The following features are available for Wagi under `feature.wagi.FEATURE`:
 | route | The relative path from the server route. e.g. "/foo" is mapped to http://example.com/foo |
 | allowed_hosts | A comma-separated list of hosts that the HTTP client is allowed to access |
 | file | If this is "true", this parcel will be treated as a file for consumption by a Wagi module |
+| argv | If this is set, use this as a template for building the `argv` array. Two values are substituted: `${SCRIPT_NAME}` is replaced with the CGI `$SCRIPT_NAME` and `${ARGS}` is replaced with the query parameters formatted for CGI. |
 
 ### Simple Bindle Example
 

--- a/src/bindle_util.rs
+++ b/src/bindle_util.rs
@@ -54,6 +54,7 @@ impl InvoiceUnderstander {
                             route: route.to_owned(),
                             entrypoint: wagi_features.get("entrypoint").map(|s| s.to_owned()),
                             allowed_hosts: wagi_features.get("allowed_hosts").map(|h| parse_csv(h)),
+                            argv: wagi_features.get("argv").map(|s| s.to_owned()),
                             required_parcels: parcels_required_for(parcel, &self.group_dependency_map),
                         };
                         Some(InterestingParcel::WagiHandler(handler_info))
@@ -87,6 +88,7 @@ pub struct WagiHandlerInfo {
     pub entrypoint: Option<String>,
     pub allowed_hosts: Option<Vec<String>>,
     pub required_parcels: Vec<Parcel>,
+    pub argv: Option<String>,
 }
 
 impl WagiHandlerInfo {

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -100,6 +100,7 @@ impl RoutingTableEntry {
             volumes: source.info.volume_mounts.clone(),
             allowed_hosts: source.info.allowed_hosts.clone(),
             http_max_concurrency: source.info.http_max_concurrency,
+            argv: source.info.argv.clone(),
         };
         let handler_info = RouteHandler::Wasm(wasm_route_handler);
 

--- a/src/handler_loader/loader.rs
+++ b/src/handler_loader/loader.rs
@@ -41,6 +41,7 @@ pub struct ModuleMapConfigurationEntry {
     pub volumes: Option<HashMap<String, String>>,
     pub allowed_hosts: Option<Vec<String>>,
     pub http_max_concurrency: Option<u32>,
+    pub argv: Option<String>,
 }
 
 pub async fn load(
@@ -132,6 +133,7 @@ impl LoadedHandlerConfigurationEntry {
             allowed_hosts: lmmce.metadata.allowed_hosts,
             http_max_concurrency: lmmce.metadata.http_max_concurrency,
             volume_mounts: lmmce.metadata.volumes.unwrap_or_default(),
+            argv: lmmce.metadata.argv,
         };
         Self {
             info,
@@ -148,6 +150,7 @@ impl LoadedHandlerConfigurationEntry {
             allowed_hosts: whi.allowed_hosts,
             http_max_concurrency: None,
             volume_mounts: bits.volume_mounts,
+            argv: whi.argv,
         };
         Self {
             info,

--- a/src/handler_loader/mod.rs
+++ b/src/handler_loader/mod.rs
@@ -28,6 +28,7 @@ pub struct HandlerInfo {
     pub allowed_hosts: Option<Vec<String>>,
     pub http_max_concurrency: Option<u32>,
     pub volume_mounts: HashMap<String, String>,
+    pub argv: Option<String>
 }
 
 pub struct WasmHandlerConfiguration {


### PR DESCRIPTION
This PR does the following:
- adds an `argv` field to `[module]` in modules.toml
- adds an `argv` feature to Bindle modules
- adds support for overriding what the `ARGV` looks like in a module invocation. In other words, you can override the CGI 1.1 format of `${SCRIPT_NAME} ${ARGS}` to be something else

## Why do we need this?

Scripting engines read files off of the filesystem and then interpret them. Examples:

- Ruby
- Python
- Node

However, they all make some assumptions about the shape of the argv array. Specifically, they assume that the array is:

```
0: script engine
1: top-level script
2...: the args that should be passed to the script
```

So, for example, a `ruby` invocation might be `ruby env.rb --some args`.

In the CGI days, we basically worked around this expectation with shell scripts. But we can't do that in Wagi. So the proposed solution is to allow the `argv` to be rewritten according to a user-specified pattern.

Example:
```
[[module]]
route = "/"
module = "ruby.wasm"
volumes = { "/" = "lib", "/usr" = "ruby-wasm32-wasi/usr" }
argv = "ruby /env.rb ${SCRIPT_NAME} ${ARGS}"
```

Take an example URL like this: `http://localhost:3000/?p1=v1&p2=v2`.

The above `argv` translates that to: `ruby /env.rb / p1=v1 p2=v2`. And `ruby.wasm` (which is `ruby` compiled to Wasm) skips arg[0], reads the `/env.rb` into the engine, and then passes that script the argv `["/", "p1=v1", "p2=v2"]`.


Signed-off-by: Matt Butcher <matt.butcher@fermyon.com>