### PR TITLE
Prepare for release v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3157,7 +3157,7 @@ checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "wagi"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
     name    = "wagi"
-    version = "0.6.2"
+    version = "0.7.0"
     authors = ["Matt Butcher <matt.butcher@microsoft.com>"]
     edition = "2021"
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -8,8 +8,8 @@ and download the desired release. Usually, the most recent release is the one yo
 You can generate and compare the SHA with `shasum`:
 
 ```console
-$ shasum wagi-v0.6.2-linux-amd64.tar.gz
-ad4114b2ed9e510a8c24348d5ea544da55c685f5  wagi-v0.6.2-linux-amd64.tar.gz
+$ shasum wagi-v0.7.0-linux-amd64.tar.gz
+ad4114b2ed9e510a8c24348d5ea544da55c685f5  wagi-v0.7.0-linux-amd64.tar.gz
 ```
 
 You can then compare that SHA with the one present in the release notes.
@@ -40,7 +40,7 @@ To build a static binary, run the following command:
 
 ```console
 $ make build
-   Compiling wagi v0.6.2 (/Users/technosophos/Code/Rust/wagi)
+   Compiling wagi v0.7.0 (/Users/technosophos/Code/Rust/wagi)
     Finished release [optimized] target(s) in 18.47s
 ```
 


### PR DESCRIPTION
Prepare for release 0.7.0.

Current CHANGELOG:

- Prepare for release v0.7.0 0c37ad606bd2c573380e8047b7d42804d1706ffc (Matt Butcher)
- feat(*): add support for http basic auth to bindle server (#165) b3d17810d777ca586d62404ebbd5dc7af04570e8 (Vaughn Dice)
- add 'argv' argument to modules.toml and bindle c5b0385f3404fb24c313b4c898e04530b122d7a8 (Matt Butcher)
- chore(handlers): Log the body of the response on parsing error 899ad669f5cd6f812245b12aa6684ed2bf502c0a (Adam Reese)
- chore: update Wasmtime to v0.34 4c8785d46c4ec6841034dd8e439197feee236816 (Radu Matei)
- Export the handlers and http_util modules b9c8192295aea138039a0716c98a2e68b0805adb (Radu Matei)
- Format cide changes fea18357f0d9f881ce61f77e903f15b81522b505 (itowlson)
- We can make the remote module resolver private to the loader pipeline too 2dcbb3a0630a052ae1193e525a68bc7fac881fe7 (itowlson)
- Tidy and unpublic some bits f5893260e553108e552e90f753b858adb7b92bd7 (itowlson)
- Slim down surface of loader system 2d42e58c68a329e85572fa1d0b641b568e67b29b (itowlson)
- Checkpoint of encapsulating the loading stuff 4a83813b5daa36db445242c70389f6007b595fdb (itowlson)
- Start to encapsulate the whole handler loading workflow aa5699815d222098f5719b1d0d4b9b4e86ec762c (itowlson)
- Split metadata for easier mapping 83dec7886cdc9e1934cbb388dc67dcf30d366ea6 (itowlson)
- Identify failed module in compile errors dbf39e677d29e6b1afe7b452f82686c87859fe1d (itowlson)
- Move compilation out of the routing table e5060e28927128bc51c86c8ce7913ff1f15e5ee7 (itowlson)
- Move destructuring into the module wrapper type c9ca306c809b5f217904dfe08cebf4dd5f81a5a4 (itowlson)
- Cleans grunkibles with fire abd4a843fd0674cee8a4f8054351092097396c2b (itowlson)
- Unify config methods before we get to the dispatcher 079781f25eab89b3ab82a8e5f56a8de54f104f1f (itowlson)


Signed-off-by: Matt Butcher <matt.butcher@fermyon.com>