### PR TITLE
Release 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3157,7 +3157,7 @@ checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "wagi"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
     name    = "wagi"
-    version = "0.7.0"
+    version = "0.8.0"
     authors = ["Matt Butcher <matt.butcher@microsoft.com>"]
     edition = "2021"
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -8,8 +8,8 @@ and download the desired release. Usually, the most recent release is the one yo
 You can generate and compare the SHA with `shasum`:
 
 ```console
-$ shasum wagi-v0.7.0-linux-amd64.tar.gz
-ad4114b2ed9e510a8c24348d5ea544da55c685f5  wagi-v0.7.0-linux-amd64.tar.gz
+$ shasum wagi-v0.8.0-linux-amd64.tar.gz
+ad4114b2ed9e510a8c24348d5ea544da55c685f5  wagi-v0.8.0-linux-amd64.tar.gz
 ```
 
 You can then compare that SHA with the one present in the release notes.
@@ -40,7 +40,7 @@ To build a static binary, run the following command:
 
 ```console
 $ make build
-   Compiling wagi v0.7.0 (/Users/technosophos/Code/Rust/wagi)
+   Compiling wagi v0.8.0 (/Users/technosophos/Code/Rust/wagi)
     Finished release [optimized] target(s) in 18.47s
 ```
 


### PR DESCRIPTION
This release fixes a unit test that will fail because of an expired certificate, and also adds a significant bug fix.

Because the unit test will fail for every build of 0.7, it seems wise to just release a new version.

Changelog:

- Release 0.8.0 54bb5c9a42e89771c9df8c8bbf956b0b857a0a63 (Matt Butcher)
- Ignore carriage returns in headers 2501e485c25366361c457ce9a56103d3dcee1cbe (Matt Butcher)
- Fixed test that is failing because of an expired SSL cert dd131e6ae1034c4f9d10858093d3ac62e3e25830 (Matt Butcher)

Signed-off-by: Matt Butcher <matt.butcher@fermyon.com>