### PR TITLE
Remove CRs only in headers

### DIFF
--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -157,7 +157,7 @@ pub fn compose_response(stdout_mutex: Arc<RwLock<Vec<u8>>>) -> Result<Response<B
     let mut out_headers: Vec<u8> = Vec::new();
     out.iter().for_each(|i| {
         // Ignore CR in headers
-        if *i == 13 {
+        if scan_headers && *i == 13 {
             return;
         } else if scan_headers && *i == 10 && last == 10 {
             out_headers.append(&mut buffer);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,7 @@ mod test {
     #[cfg(target_os = "windows")]
     const TEST2_MODULE_MAP_FILE: &str = "test2.toml";
     const TEST3_MODULE_MAP_FILE: &str = "test3.toml";
+    const WAT_MODULE_MAP_FILE: &str = "wat.toml";
     const TEST_HEALTHZ_MODULE_MAP_FILE: &str = "test_healthz_override.toml";
     const TEST_DYNAMIC_ROUTES_MODULE_MAP_FILE: &str = "test_dynamic_routes.toml";
 
@@ -339,6 +340,14 @@ mod test {
             let response = get_plain_text_response_from_module_map(TEST3_MODULE_MAP_FILE, None, route).await;
             assert_eq!("Entrypoint 2\n", response);
         }
+    }
+
+    #[tokio::test]
+    pub async fn can_serve_wat() {
+        let route = "/";
+
+        let response = get_plain_text_response_from_module_map(WAT_MODULE_MAP_FILE, None, route).await;
+        assert_eq!("Oh hi world\r\n", response);
     }
 
     fn parse_ev_line(line: &str) -> Option<(String, String)> {

--- a/testdata/module-maps/crlf.wat
+++ b/testdata/module-maps/crlf.wat
@@ -1,0 +1,20 @@
+(module
+    (import "wasi_snapshot_preview1" "fd_write" (func $fd_write (param i32 i32 i32 i32) (result i32)))
+    (memory 1)
+    (export "memory" (memory 0))
+
+    (data (i32.const 8) "content-type: text/plain\r\n\r\nOh hi world\r\n")
+
+    (func $main (export "_start")
+        (i32.store (i32.const 0) (i32.const 8))
+        (i32.store (i32.const 4) (i32.const 41))
+
+        (call $fd_write
+            (i32.const 1)
+            (i32.const 0)
+            (i32.const 1)
+            (i32.const 20)
+        )
+        drop
+    )
+)

--- a/testdata/module-maps/wat.toml
+++ b/testdata/module-maps/wat.toml
@@ -1,0 +1,3 @@
+[[module]]
+route = "/"
+module = "file:///${PROJECT_ROOT}/testdata/module-maps/crlf.wat"


### PR DESCRIPTION
This PR does the following:
- Fixes a regression where we stripped too many carriage returns. 
- Adds a test that verifies both this and that Wagi can run WAT files

Signed-off-by: Matt Butcher <matt.butcher@fermyon.com>